### PR TITLE
Implement product detail page

### DIFF
--- a/fake-server/db.json
+++ b/fake-server/db.json
@@ -1,5 +1,5 @@
 {
-  "items": [
+  "products": [
     {
       "id": 1,
       "title": "크리넥스 KF-AD 소형 마스크 팝니다.",

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <link rel="stylesheet" href="default.css">
+  <link rel="stylesheet" href="/default.css">
   <title>Kcena Market</title>
 </head>
 <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,21 @@
 import React from 'react';
-
-import ProductsContainer from './components/container/ProductsContainer';
+import {
+  Switch, Route,
+} from 'react-router-dom';
 
 import Header from './styles/Header';
 import Layout from './styles/Layout';
+import HomePage from './pages/HomePage';
+import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
   return (
     <Layout>
       <Header />
-      <Layout.Main>
-        <Layout.Title>Kcena Market 인기 매물</Layout.Title>
-        <Layout.TextLineDivider />
-        <ProductsContainer />
-      </Layout.Main>
+      <Switch>
+        <Route exact path="/" component={HomePage} />
+        <Route component={NotFoundPage} />
+      </Switch>
     </Layout>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Switch, Route,
+  Switch, Route, Link,
 } from 'react-router-dom';
 
 import Header from './styles/Header';
@@ -12,7 +12,9 @@ import ProductPage from './pages/ProductPage';
 export default function App() {
   return (
     <Layout>
-      <Header />
+      <Header>
+        <Link to="/">Kcena Market</Link>
+      </Header>
       <Layout.Main>
         <Switch>
           <Route exact path="/" component={HomePage} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,15 +7,19 @@ import Header from './styles/Header';
 import Layout from './styles/Layout';
 import HomePage from './pages/HomePage';
 import NotFoundPage from './pages/NotFoundPage';
+import ProductPage from './pages/ProductPage';
 
 export default function App() {
   return (
     <Layout>
       <Header />
-      <Switch>
-        <Route exact path="/" component={HomePage} />
-        <Route component={NotFoundPage} />
-      </Switch>
+      <Layout.Main>
+        <Switch>
+          <Route exact path="/" component={HomePage} />
+          <Route path="/products/:id" component={ProductPage} />
+          <Route component={NotFoundPage} />
+        </Switch>
+      </Layout.Main>
     </Layout>
   );
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
 
@@ -19,8 +20,24 @@ describe('App', () => {
   });
 
   it('renders Title', () => {
-    const { container } = render(<App />);
+    const { container } = render((
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    ));
 
     expect(container).toHaveTextContent('Kcena Market');
+  });
+
+  context('with invalid path', () => {
+    it('renders the not found page', () => {
+      const { container } = render((
+        <MemoryRouter initialEntries={['/invalid']}>
+          <App />
+        </MemoryRouter>
+      ));
+
+      expect(container).toHaveTextContent('Not Found');
+    });
   });
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,6 @@
 import {
   fetchProducts,
+  fetchProduct,
 } from './services/api';
 
 export function setProducts(products) {
@@ -13,5 +14,19 @@ export function loadInitProducts() {
   return async (dispatch) => {
     const products = await fetchProducts();
     dispatch(setProducts(products));
+  };
+}
+
+export function setProduct(product) {
+  return {
+    type: 'setProduct',
+    payload: { product },
+  };
+}
+
+export function loadProduct({ productId }) {
+  return async (dispatch) => {
+    const product = await fetchProduct(productId);
+    dispatch(setProduct(product));
   };
 }

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -4,7 +4,9 @@ import configureStore from 'redux-mock-store';
 
 import {
   setProducts,
+  setProduct,
   loadInitProducts,
+  loadProduct,
 } from './actions';
 
 const middlewares = [thunk];
@@ -26,6 +28,20 @@ describe('actions', () => {
       const actions = store.getActions();
 
       expect(actions[0]).toEqual(setProducts([]));
+    });
+  });
+
+  describe('loadProduct', () => {
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    it('dispatchs setProduct', async () => {
+      await store.dispatch(loadProduct({ productId: 1 }));
+
+      const actions = store.getActions();
+
+      expect(actions[0]).toEqual(setProduct({}));
     });
   });
 });

--- a/src/components/container/ProductContainer.jsx
+++ b/src/components/container/ProductContainer.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import ProductDetail from '../presentational/ProductDetail';
+
+import { loadProduct } from '../../actions';
+
+import { get } from '../../utils';
+
+export default function ProductContainer({ productId }) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadProduct({ productId }));
+  }, []);
+
+  const product = useSelector(get('product'));
+
+  if (!product) {
+    return (
+      <p>loading...</p>
+    );
+  }
+
+  return (
+    <ProductDetail product={product} />
+  );
+}

--- a/src/components/container/ProductContainer.test.jsx
+++ b/src/components/container/ProductContainer.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import ProductContainer from './ProductContainer';
+
+import products from '../../../fixtures/products';
+
+jest.mock('react-redux');
+
+describe('ProductContainer', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    useDispatch.mockImplementation(() => dispatch);
+    useSelector.mockImplementation((selector) => selector({
+      product: given.product,
+    }));
+  });
+
+  function renderProductContainer() {
+    return render((
+      <ProductContainer productId="1" />
+    ));
+  }
+
+  context('with product', () => {
+    given('product', () => products[0]);
+
+    it('dispatchs called', () => {
+      renderProductContainer();
+
+      expect(dispatch).toBeCalled();
+    });
+
+    it('renders product', () => {
+      const { container } = renderProductContainer();
+
+      expect(container).toHaveTextContent('크리넥스 KF-AD 소형 마스크 팝니다.');
+      expect(container).toHaveTextContent('미추홀구 용현5동');
+    });
+  });
+
+  context('without product', () => {
+    given('empty product', () => {});
+    it('renders loading message', () => {
+      const { container } = renderProductContainer();
+
+      expect(container).toHaveTextContent('loading...');
+    });
+  });
+});

--- a/src/components/container/ProductsContainer.jsx
+++ b/src/components/container/ProductsContainer.jsx
@@ -10,7 +10,7 @@ import {
   loadInitProducts,
 } from '../../actions';
 
-export default function ProductsContainer() {
+export default function ProductsContainer({ onClickProduct }) {
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -20,6 +20,9 @@ export default function ProductsContainer() {
   const products = useSelector(get('products'));
 
   return (
-    <Products products={products} />
+    <Products
+      products={products}
+      onClickProduct={onClickProduct}
+    />
   );
 }

--- a/src/components/container/ProductsContainer.test.jsx
+++ b/src/components/container/ProductsContainer.test.jsx
@@ -17,6 +17,7 @@ describe('ProductsContainer', () => {
       <ProductsContainer />
     ));
   }
+
   beforeEach(() => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);

--- a/src/components/presentational/Product.jsx
+++ b/src/components/presentational/Product.jsx
@@ -10,7 +10,7 @@ import {
 
 export default function Product({ product, onClickProduct }) {
   const {
-    title, thumbnailUrl, region, price,
+    id, title, thumbnailUrl, region, price,
   } = product;
 
   function handleClick(selectedProduct) {
@@ -23,7 +23,7 @@ export default function Product({ product, onClickProduct }) {
   return (
     <CardItem>
       <CardArticle>
-        <CardLink href="/products/1" onClick={handleClick(product)}>
+        <CardLink href={`/products/${id}`} onClick={handleClick(product)}>
           <CardImage url={thumbnailUrl}>
             <img src={thumbnailUrl} alt={title} />
           </CardImage>

--- a/src/components/presentational/Product.jsx
+++ b/src/components/presentational/Product.jsx
@@ -8,15 +8,22 @@ import {
   CardDescription,
 } from '../../styles/Card';
 
-export default function Product({
-  product: {
-    title, thumbnailUrl, url, region, price,
-  },
-}) {
+export default function Product({ product, onClickProduct }) {
+  const {
+    title, thumbnailUrl, region, price,
+  } = product;
+
+  function handleClick(selectedProduct) {
+    return (event) => {
+      event.preventDefault();
+      onClickProduct(selectedProduct);
+    };
+  }
+
   return (
     <CardItem>
       <CardArticle>
-        <CardLink href={url}>
+        <CardLink href="/products/1" onClick={handleClick(product)}>
           <CardImage url={thumbnailUrl}>
             <img src={thumbnailUrl} alt={title} />
           </CardImage>

--- a/src/components/presentational/Product.test.jsx
+++ b/src/components/presentational/Product.test.jsx
@@ -1,34 +1,40 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import Product from './Product';
 
 describe('Product', () => {
+  const handleClickProduct = jest.fn();
+
   const product = {
     title: '청바지',
     region: '인천광역시 미추홀구',
-    url: 'https://www.test.com/',
     price: '10,000',
   };
 
   function renderProduct() {
     return render((
-      <Product product={product} />
+      <Product
+        product={product}
+        onClickProduct={handleClickProduct}
+      />
     ));
   }
 
   it('renders product', () => {
     const { getByText } = renderProduct();
 
-    expect(getByText('청바지')).not.toBeNull();
-    expect(getByText('인천광역시 미추홀구')).not.toBeNull();
-    expect(getByText('10,000원')).not.toBeNull();
+    expect(getByText(product.title)).not.toBeNull();
+    expect(getByText(product.region)).not.toBeNull();
+    expect(getByText(`${product.price}원`)).not.toBeNull();
   });
 
-  it('click to go to the product link', () => {
+  it('listens click event', () => {
     const { getByText } = renderProduct();
 
-    expect(getByText('청바지').closest('a')).toHaveAttribute('href', 'https://www.test.com/');
+    fireEvent.click(getByText(product.title));
+
+    expect(handleClickProduct).toBeCalled();
   });
 });

--- a/src/components/presentational/ProductDetail.jsx
+++ b/src/components/presentational/ProductDetail.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function ProductDetail({ product }) {
+  const { title, region, price } = product;
+
+  return (
+    <div>
+      <h3>{title}</h3>
+      <div>{region}</div>
+      <div>{price}</div>
+    </div>
+  );
+}

--- a/src/components/presentational/ProductDetail.jsx
+++ b/src/components/presentational/ProductDetail.jsx
@@ -1,13 +1,38 @@
 import React from 'react';
+import styled from '@emotion/styled';
+
+const Article = styled.article({
+
+});
+
+const ArticleImages = styled.section({
+
+});
+
+const ArticleProfile = styled.section({
+
+});
+
+const ArticleDescription = styled.section({
+
+});
 
 export default function ProductDetail({ product }) {
-  const { title, region, price } = product;
+  const {
+    title, thumbnailUrl, region, price,
+  } = product;
 
   return (
-    <div>
-      <h3>{title}</h3>
-      <div>{region}</div>
-      <div>{price}</div>
-    </div>
+    <Article>
+      <ArticleImages>
+        <img src={thumbnailUrl} alt={title} />
+      </ArticleImages>
+      <ArticleProfile />
+      <ArticleDescription>
+        <h1>{title}</h1>
+        <div>{region}</div>
+        <div>{price}</div>
+      </ArticleDescription>
+    </Article>
   );
 }

--- a/src/components/presentational/ProductDetail.test.jsx
+++ b/src/components/presentational/ProductDetail.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import ProductDetail from './ProductDetail';
+
+import products from '../../../fixtures/products';
+
+describe('ProductDetail', () => {
+  it('renders product detail', () => {
+    const { container } = render((
+      <ProductDetail
+        product={products[0]}
+      />
+    ));
+
+    expect(container).toHaveTextContent('크리넥스 KF-AD 소형 마스크 팝니다.');
+    expect(container).toHaveTextContent('미추홀구 용현5동');
+  });
+});

--- a/src/components/presentational/Products.jsx
+++ b/src/components/presentational/Products.jsx
@@ -3,7 +3,7 @@ import Product from './Product';
 
 import { CardList } from '../../styles/Card';
 
-export default function Products({ products }) {
+export default function Products({ products, onClickProduct }) {
   if (!(products || []).length) {
     return (
       <p>품목이 없습니다!</p>
@@ -13,7 +13,11 @@ export default function Products({ products }) {
   return (
     <CardList>
       {products.map((product) => (
-        <Product key={product.id} product={product} />
+        <Product
+          key={product.id}
+          product={product}
+          onClickProduct={onClickProduct}
+        />
       ))}
     </CardList>
   );

--- a/src/components/presentational/Products.test.jsx
+++ b/src/components/presentational/Products.test.jsx
@@ -7,10 +7,15 @@ import Products from './Products';
 import products from '../../../fixtures/products';
 
 describe('Products', () => {
+  const handleClickProduct = jest.fn();
+
   context('with products', () => {
     it('renders products', () => {
       const { container } = render((
-        <Products products={products} />
+        <Products
+          products={products}
+          onClickProduct={handleClickProduct}
+        />
       ));
 
       products.forEach(({ title, region, price }) => {
@@ -25,7 +30,10 @@ describe('Products', () => {
     it('renders no products message', () => {
       [[], undefined, null].forEach((emptyProducts) => {
         const { container } = render((
-          <Products products={emptyProducts} />
+          <Products
+            products={emptyProducts}
+            onClickProduct={handleClickProduct}
+          />
         ));
 
         expect(container).toHaveTextContent('품목이 없습니다!');

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 
@@ -9,7 +10,9 @@ import store from '../store';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   ),
   document.getElementById('app'),

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import Layout from '../styles/Layout';
+
+import ProductsContainer from '../components/container/ProductsContainer';
+
+export default function HomePage() {
+  const history = useHistory();
+
+  function handleClickProduct(product) {
+    const url = `/products/${product.id}`;
+    history.push(url);
+  }
+
+  return (
+    <Layout.Main>
+      <Layout.Title>Kcena Market 인기 매물</Layout.Title>
+      <Layout.TextLineDivider />
+      <ProductsContainer onClickProduct={handleClickProduct} />
+    </Layout.Main>
+  );
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -14,10 +14,10 @@ export default function HomePage() {
   }
 
   return (
-    <Layout.Main>
+    <>
       <Layout.Title>Kcena Market 인기 매물</Layout.Title>
       <Layout.TextLineDivider />
       <ProductsContainer onClickProduct={handleClickProduct} />
-    </Layout.Main>
+    </>
   );
 }

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import HomePage from './HomePage';
+
+import products from '../../fixtures/products';
+
+const mockPush = jest.fn();
+
+jest.mock('react-redux');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory() {
+    return { push: mockPush };
+  },
+}));
+
+describe('HomePage', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    useDispatch.mockImplementation(() => dispatch);
+    useSelector.mockImplementation((selector) => selector({
+      products,
+    }));
+  });
+
+  function renderHomePage() {
+    return render((
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    ));
+  }
+
+  it('renders products', () => {
+    const { container } = renderHomePage();
+
+    products.forEach(({ title, region, price }) => {
+      expect(container).toHaveTextContent(title);
+      expect(container).toHaveTextContent(region);
+      expect(container).toHaveTextContent(price);
+    });
+  });
+
+  context('when click product', () => {
+    it('occur handle event', () => {
+      const { getByText } = renderHomePage();
+
+      fireEvent.click(getByText('크리넥스 KF-AD 소형 마스크 팝니다.'));
+
+      expect(mockPush).toBeCalledWith('/products/1');
+    });
+  });
+});

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function NotFoundPage() {
+  return (
+    <p>404 Not Found</p>
+  );
+}

--- a/src/pages/NotFoundPage.test.jsx
+++ b/src/pages/NotFoundPage.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import NotFoundPage from './NotFoundPage';
+
+test('NotFoundPage', () => {
+  render(<NotFoundPage />);
+});

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import ProductContainer from '../components/container/ProductContainer';
+
+export default function ProductPage({ params }) {
+  const { id } = params || useParams();
+
+  return (
+    <ProductContainer productId={id} />
+  );
+}

--- a/src/pages/ProductPage.test.jsx
+++ b/src/pages/ProductPage.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { MemoryRouter } from 'react-router-dom';
+import ProductPage from './ProductPage';
+
+import products from '../../fixtures/products';
+
+describe('ProductPage', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    useDispatch.mockImplementation(() => dispatch);
+    useSelector.mockImplementation((selector) => selector({
+      product: products[0],
+    }));
+  });
+
+  context('with params props', () => {
+    it('renders product', () => {
+      const params = { productId: 1 };
+      const { container } = render((
+        <ProductPage params={params} />
+      ));
+
+      expect(container).toHaveTextContent('크리넥스 KF-AD 소형 마스크 팝니다.');
+      expect(container).toHaveTextContent('미추홀구 용현5동');
+    });
+  });
+
+  context('without params props', () => {
+    it('renders product', () => {
+      const { container } = render((
+        <MemoryRouter initialEntries={['/products/1']}>
+          <ProductPage />
+        </MemoryRouter>
+      ));
+
+      expect(container).toHaveTextContent('크리넥스 KF-AD 소형 마스크 팝니다.');
+      expect(container).toHaveTextContent('미추홀구 용현5동');
+    });
+  });
+});

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,4 +1,5 @@
 const initialState = {
+  product: null,
   products: [],
 };
 
@@ -7,6 +8,12 @@ const reducers = {
     return {
       ...state,
       products,
+    };
+  },
+  setProduct(state, { payload: { product } }) {
+    return {
+      ...state,
+      product,
     };
   },
 };

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -2,6 +2,7 @@ import reducer from './reducer';
 
 import {
   setProducts,
+  setProduct,
 } from './actions';
 
 import products from '../fixtures/products';
@@ -9,6 +10,7 @@ import products from '../fixtures/products';
 describe('reducer', () => {
   context('when previous state is undefined', () => {
     const initialState = {
+      product: null,
       products: [],
     };
 
@@ -29,5 +31,18 @@ describe('reducer', () => {
 
       expect(state.products).toEqual(products);
     });
+  });
+
+  describe('setProduct', () => {
+    const initialState = {
+      product: null,
+    };
+
+    const product = products[0];
+
+    const state = reducer(initialState, setProduct(product));
+
+    expect(state.product.id).toBe(1);
+    expect(state.product.title).toBe('크리넥스 KF-AD 소형 마스크 팝니다.');
   });
 });

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -2,6 +2,6 @@ export async function fetchProducts() {
   return [];
 }
 
-export async function xxx() {
-  // TOOD: ...
+export async function fetchProduct() {
+  return {};
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,6 +5,9 @@ export async function fetchProducts() {
   return data;
 }
 
-export async function xxx() {
-  // TODO: ...
+export async function fetchProduct(productId) {
+  const url = `http://localhost:3001/products/${productId}`;
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,5 +1,5 @@
 export async function fetchProducts() {
-  const url = 'http://localhost:3001/items';
+  const url = 'http://localhost:3001/products';
   const response = await fetch(url);
   const data = await response.json();
   return data;

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,5 +1,6 @@
 import {
   fetchProducts,
+  fetchProduct,
 } from './api';
 
 import mockProducts from '../../fixtures/products';
@@ -20,6 +21,18 @@ describe('api', () => {
       const products = await fetchProducts();
 
       expect(products).toEqual(mockProducts);
+    });
+  });
+
+  describe('fetchProduct', () => {
+    beforeEach(() => {
+      mockFetch(mockProducts[0]);
+    });
+
+    it('returns product', async () => {
+      const product = await fetchProduct();
+
+      expect(product).toEqual(mockProducts[0]);
     });
   });
 });

--- a/src/styles/Header.jsx
+++ b/src/styles/Header.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
 
-const Wrapper = styled.header({
+const Header = styled.header({
   fontFamily: 'Baloo, cursive',
   display: 'flex',
   position: 'fixed',
@@ -15,12 +13,13 @@ const Wrapper = styled.header({
   zIndex: '100',
   top: '0px',
   boxShadow: '0 3px 6px rgba(0,0,0,0.10), 0 3px 6px rgba(0,0,0,0.20)',
+  '& a': {
+    color: '#555',
+    textDecoration: 'none',
+    '&:hover': {
+      color: '#000',
+    },
+  },
 });
-
-const Header = () => (
-  <Wrapper>
-    Kcena Market
-  </Wrapper>
-);
 
 export default Header;

--- a/test/not_found_test.js
+++ b/test/not_found_test.js
@@ -1,0 +1,7 @@
+Feature('NotFound');
+
+Scenario('존재하지 않는 url 접근 시 NotFound 페이지를 보여준다.', (I) => {
+  I.amOnPage('/any_not_exist_url');
+
+  I.see('404 Not Found');
+});


### PR DESCRIPTION
![Implement product detail page](https://user-images.githubusercontent.com/45390172/89707727-ccfd2a80-d9ab-11ea-93c7-25d0ec635cf5.gif)
- 상품을 클릭하면 상품 상세 페이지로 이동하도록 `react router dom` 을 적용하였다.
- 상세 페이지의 스타일은 추후에 적용하도록 하고, 그 전에 먼저 레이아웃을 잡아 두었다.