### PR TITLE
Subscribe auth state using local storage

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import 'jest-localstorage-mock';
 import 'raf/polyfill';
 
 window.matchMedia = window.matchMedia || function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9293,6 +9293,12 @@
         "pretty-format": "^26.1.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.3.tgz",
+      "integrity": "sha512-UgifkHKoWVRUoSqO4Z4Z+Hl1NbiYBVDlmkmulFFeRRneGECWAlAdGWJdyz+2NisjOZnnQoxQl0s5dQ7ch62Jxw==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "file-loader": "^6.0.0",
     "given2": "^2.1.7",
     "jest": "^26.1.0",
+    "jest-localstorage-mock": "^2.4.3",
     "jest-plugin-context": "^2.9.0",
     "puppeteer": "^5.2.1",
     "raf": "^3.4.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import {
   Switch, Route,
 } from 'react-router-dom';
 
+import { useDispatch } from 'react-redux';
+
 import Header from './components/presentational/Header';
 import Layout from './styles/Layout';
 import HomePage from './pages/HomePage';
@@ -11,7 +13,18 @@ import SignupPage from './pages/SignupPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ProductPage from './pages/ProductPage';
 
+import { setUser } from './slice';
+
+import { loadItem } from './services/storage';
+
 export default function App() {
+  const dispatch = useDispatch();
+
+  const user = loadItem('user');
+  if (user) {
+    dispatch(setUser(user));
+  }
+
   return (
     <Layout>
       <Header />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,19 +1,31 @@
 import React from 'react';
 
+import configureStore from 'redux-mock-store';
+import { getDefaultMiddleware } from '@reduxjs/toolkit';
+
 import { render, fireEvent } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
 
+import { loadItem } from './services/storage';
+
 import products from '../fixtures/products';
 
 jest.mock('react-redux');
+jest.mock('./services/storage');
+jest.mock('./services/api');
+
+const mockStore = configureStore(getDefaultMiddleware());
+let store;
 
 describe('App', () => {
-  const dispatch = jest.fn();
   beforeEach(() => {
-    useDispatch.mockImplementation(() => dispatch);
+    store = mockStore({});
+
+    useDispatch.mockImplementation(() => store.dispatch);
+
     useSelector.mockImplementation((selector) => selector({
       products,
       loginFields: {
@@ -31,22 +43,23 @@ describe('App', () => {
     }));
   });
 
-  it('renders Title', () => {
-    const { container } = render((
-      <MemoryRouter>
+  function renderApp({ path }) {
+    return render(
+      <MemoryRouter initialEntries={[path]}>
         <App />
-      </MemoryRouter>
-    ));
+      </MemoryRouter>,
+    );
+  }
+
+  it('renders Title', () => {
+    const { container } = renderApp({ path: '/' });
 
     expect(container).toHaveTextContent('Kcena Market');
   });
 
   it('navigates home when you click the logo', () => {
-    const { container, getByText } = render(
-      <MemoryRouter initialEntries={['/invalid']}>
-        <App />
-      </MemoryRouter>,
-    );
+    const { container, getByText } = renderApp({ path: '/invalid' });
+
     expect(container).toHaveTextContent('404 Not Found');
 
     const goHomeLink = getByText('Kcena Market');
@@ -56,22 +69,14 @@ describe('App', () => {
   });
 
   it('navigates log in when you click the "log in"', () => {
-    const { getByLabelText } = render(
-      <MemoryRouter initialEntries={['/login']}>
-        <App />
-      </MemoryRouter>,
-    );
+    const { getByLabelText } = renderApp({ path: '/login' });
 
     expect(getByLabelText('E-mail')).not.toBeNull();
     expect(getByLabelText('Password')).not.toBeNull();
   });
 
   it('navigates Sign up when you click the "Sign up"', () => {
-    const { getByLabelText } = render(
-      <MemoryRouter initialEntries={['/signup']}>
-        <App />
-      </MemoryRouter>,
-    );
+    const { getByLabelText } = renderApp({ path: '/signup' });
 
     expect(getByLabelText('E-mail')).not.toBeNull();
     expect(getByLabelText('Password')).not.toBeNull();
@@ -79,13 +84,45 @@ describe('App', () => {
 
   context('with invalid path', () => {
     it('renders the not found page', () => {
-      const { container } = render((
-        <MemoryRouter initialEntries={['/invalid']}>
-          <App />
-        </MemoryRouter>
-      ));
+      const { container } = renderApp({ path: '/invalid' });
 
       expect(container).toHaveTextContent('Not Found');
+    });
+  });
+
+  context('with logged in', () => {
+    const mockUser = {
+      displayName: 'tester',
+      uid: '123456',
+    };
+
+    beforeEach(() => {
+      loadItem.mockImplementation(() => mockUser);
+    });
+
+    it('dispatchs call with user', () => {
+      renderApp({ path: '/' });
+
+      const actions = store.getActions();
+
+      expect(actions[0]).toEqual({
+        type: 'application/setUser',
+        payload: mockUser,
+      });
+    });
+  });
+
+  context('with logged out', () => {
+    beforeEach(() => {
+      loadItem.mockImplementation(() => null);
+    });
+
+    it('doesn\'t call dispatch', () => {
+      renderApp({ path: '/' });
+
+      const actions = store.getActions();
+
+      expect(actions).toEqual([]);
     });
   });
 });

--- a/src/services/__mocks__/storage.js
+++ b/src/services/__mocks__/storage.js
@@ -1,0 +1,7 @@
+const saveItem = jest.fn();
+const loadItem = jest.fn();
+
+export {
+  saveItem,
+  loadItem,
+};

--- a/src/services/__mocks__/storage.js
+++ b/src/services/__mocks__/storage.js
@@ -1,7 +1,9 @@
 const saveItem = jest.fn();
 const loadItem = jest.fn();
+const deleteItem = jest.fn();
 
 export {
   saveItem,
   loadItem,
+  deleteItem,
 };

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,0 +1,7 @@
+export function saveItem(key, value) {
+  return localStorage.setItem(key, value);
+}
+
+export function loadItem(key) {
+  return localStorage.getItem(key);
+}

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -5,3 +5,7 @@ export function saveItem(key, value) {
 export function loadItem(key) {
   return JSON.parse(localStorage.getItem(key));
 }
+
+export function deleteItem(key) {
+  return localStorage.removeItem(key);
+}

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,7 +1,7 @@
 export function saveItem(key, value) {
-  return localStorage.setItem(key, value);
+  return localStorage.setItem(key, JSON.stringify(value));
 }
 
 export function loadItem(key) {
-  return localStorage.getItem(key);
+  return JSON.parse(localStorage.getItem(key));
 }

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -1,4 +1,4 @@
-import { saveItem, loadItem } from './storage';
+import { saveItem, loadItem, deleteItem } from './storage';
 
 describe('localStorage', () => {
   const KEY = 'user';
@@ -22,5 +22,11 @@ describe('localStorage', () => {
     loadItem(KEY);
 
     expect(localStorage.getItem).toHaveBeenLastCalledWith(KEY);
+  });
+
+  it('delete to localStorage', () => {
+    deleteItem(KEY);
+
+    expect(localStorage.removeItem).toHaveBeenLastCalledWith(KEY);
   });
 });

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -1,0 +1,25 @@
+import { saveItem, loadItem } from './storage';
+
+describe('localStorage', () => {
+  const KEY = 'user';
+  const VALUE = {
+    displayName: 'tester',
+    uid: '123456',
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('save to localStorage', () => {
+    saveItem(KEY, VALUE);
+
+    expect(localStorage.setItem).toHaveBeenLastCalledWith(KEY, VALUE);
+  });
+
+  it('load to localStorage', () => {
+    loadItem(KEY);
+
+    expect(localStorage.getItem).toHaveBeenLastCalledWith(KEY);
+  });
+});

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -14,7 +14,8 @@ describe('localStorage', () => {
   it('save to localStorage', () => {
     saveItem(KEY, VALUE);
 
-    expect(localStorage.setItem).toHaveBeenLastCalledWith(KEY, VALUE);
+    expect(localStorage.setItem)
+      .toHaveBeenLastCalledWith(KEY, JSON.stringify(VALUE));
   });
 
   it('load to localStorage', () => {

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,5 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { saveItem, deleteItem } from './services/storage';
+
 import {
   fetchProducts,
   fetchProduct,
@@ -117,13 +119,11 @@ export function requestLogin() {
   return async (dispatch, getState) => {
     const { loginFields: { email, password } } = getState();
     try {
-      const {
-        user: {
-          displayName, uid,
-        },
-      } = await postLogin({ email, password });
+      const { user } = await postLogin({ email, password });
+      const { displayName, uid } = user;
 
       dispatch(setUser({ displayName, uid }));
+      saveItem('user', { displayName, uid });
     } catch (error) {
       dispatch(setError(error.message));
     }
@@ -133,13 +133,11 @@ export function requestLogin() {
 export function requestGoogleSignIn() {
   return async (dispatch) => {
     try {
-      const {
-        user: {
-          displayName, uid,
-        },
-      } = await postGoogleSignIn();
+      const { user } = await postGoogleSignIn();
+      const { displayName, uid } = user;
 
       dispatch(setUser({ displayName, uid }));
+      saveItem('user', { displayName, uid });
     } catch (error) {
       dispatch(setError(error.message));
     }
@@ -150,12 +148,10 @@ export function requestSignup() {
   return async (dispatch, getState) => {
     const { signupFields: { email, password } } = getState();
     try {
-      const {
-        user: {
-          displayName, uid,
-        },
-      } = await postSignup({ email, password });
+      const { user } = await postSignup({ email, password });
+      const { displayName, uid } = user;
       dispatch(setUser({ displayName, uid }));
+      saveItem('user', { displayName, uid });
     } catch (error) {
       dispatch(setError(error.message));
     }
@@ -166,6 +162,7 @@ export function requestLogout() {
   return async (dispatch) => {
     await postLogout();
     dispatch(logout());
+    deleteItem('user');
   };
 }
 


### PR DESCRIPTION
# 새로고침 이후에도 로그인 상태를 유지하기

## 테스트 하면서 발생했던 문제점

로그인을 헀었다면 `localStorage`에 `user`의 정보가 저장되어 있기 때문에,  새로고침 이후에도 로그인 정보가 유지되도록 아래와 같이 코드를 작성하였다.
```javascript
...
  const dispatch = useDispatch();

  const user = loadItem('user');
  if (user) {
    dispatch(setUser(user));
  }
...
```
이 부분에 대한 테스트는 매우 간단하다고 생각하였다. 
```javascript
context('with logged in', () => {
  const mockUser = {
    displayName: 'tester',
    uid: '123456',
  };

  beforeEach(() => {
    loadItem.mockImplementation(() => mockUser);
  });

  it('dispatchs call with user', () => {
    renderApp({ path: '/' });

    expect(dispatch).toBeCalledWith({
      type: 'application/setUser',
      payload: mockUser,
    });
  });
});

context('with logged out', () => {
  beforeEach(() => {
    loadItem.mockImplementation(() => null);
  });

  it('doesn\'t call dispatch', () => {
    renderApp({ path: '/' });

    expect(dispatch).not.toBeCalled();
  });
});
```
하지만 의도와는 다르게 엉뚱한 곳에서 dispatch가 호출되었는데, 이는 `ProductsContainer` 부분에서 호출되는 것이었다. 홈페이지가 처음 렌더링 될 때 초기 상품 목록을 가져오는 `dispatch`가 호출되는 것이 잡힌 것이다. 

이를 해결하기 위해서 redux-mock-store 를 사용하여 실제 호출되는 actions이 무엇인지 판단하려 했는데 예상대로라면

`with logged in` 테스트 부분에서의 actions은 아래와 같고,
```
[
  {
    type: 'application/setUser',
    payload: { displayName: 'tester', uid: '123456' }
  }
]
```

with logged out 부분에서는 ProductsContainer 에서 호출하는 dispatch 가 들어있어야 한다고 생각했다.
```
[
  { type: 'application/setProducts', payload: [] }
]
```

그런데 예상했던거와 다르게 with logged out 부분은 빈 배열만 담겨 있었다.

App 컴포넌트에서만 호출하는 actions 의 관점에서는 맞다고 생각하는데, 이전에는 문제가 되었던 `ProductsContainer` 에서 호출하던거 까지 잡다가 이번에는 안잡는게 의문이다.