### PR TITLE
Redirect homepage after user sign in or sign up

### DIFF
--- a/__mocks__/connected-react-router.js
+++ b/__mocks__/connected-react-router.js
@@ -1,0 +1,3 @@
+const push = jest.fn();
+
+export default push;

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -27,18 +27,20 @@ describe('App', () => {
     useDispatch.mockImplementation(() => store.dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      products,
-      loginFields: {
-        email: '',
-        password: '',
-      },
-      signupFields: {
-        email: '',
-        password: '',
-      },
-      user: {
-        uid: '',
-        displayName: '',
+      reducer: {
+        products,
+        loginFields: {
+          email: '',
+          password: '',
+        },
+        signupFields: {
+          email: '',
+          password: '',
+        },
+        user: {
+          uid: '',
+          displayName: '',
+        },
       },
     }));
   });

--- a/src/components/container/LoginFormContainer.jsx
+++ b/src/components/container/LoginFormContainer.jsx
@@ -17,9 +17,13 @@ import { get } from '../../utils';
 export default function LoginFormContainer() {
   const dispatch = useDispatch();
 
-  const { email, password } = useSelector(get('loginFields'));
-  const user = useSelector(get('user'));
-  const error = useSelector(get('error'));
+  const {
+    user,
+    error,
+    loginFields: {
+      email, password,
+    },
+  } = useSelector(get('reducer'));
 
   function handleChange({ name, value }) {
     dispatch(changeLoginField({ name, value }));

--- a/src/components/container/LoginFormContainer.test.jsx
+++ b/src/components/container/LoginFormContainer.test.jsx
@@ -14,12 +14,14 @@ describe('LoginFormContainer', () => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
     useSelector.mockImplementation((selector) => selector({
-      loginFields: {
-        email: 'test@test',
-        password: '1234',
+      reducer: {
+        loginFields: {
+          email: 'test@test',
+          password: '1234',
+        },
+        user: given.user,
+        error: given.error,
       },
-      user: given.user,
-      error: given.error,
     }));
   });
 

--- a/src/components/container/ProductContainer.jsx
+++ b/src/components/container/ProductContainer.jsx
@@ -14,7 +14,7 @@ export default function ProductContainer({ productId }) {
     dispatch(loadProduct({ productId }));
   }, []);
 
-  const product = useSelector(get('product'));
+  const { product } = useSelector(get('reducer'));
 
   if (!product) {
     return (

--- a/src/components/container/ProductContainer.test.jsx
+++ b/src/components/container/ProductContainer.test.jsx
@@ -16,7 +16,9 @@ describe('ProductContainer', () => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
     useSelector.mockImplementation((selector) => selector({
-      product: given.product,
+      reducer: {
+        product: given.product,
+      },
     }));
   });
 

--- a/src/components/container/ProductsContainer.jsx
+++ b/src/components/container/ProductsContainer.jsx
@@ -17,7 +17,7 @@ export default function ProductsContainer({ onClickProduct }) {
     dispatch(loadInitProducts());
   }, []);
 
-  const products = useSelector(get('products'));
+  const { products } = useSelector(get('reducer'));
 
   return (
     <Products

--- a/src/components/container/ProductsContainer.test.jsx
+++ b/src/components/container/ProductsContainer.test.jsx
@@ -22,7 +22,9 @@ describe('ProductsContainer', () => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
     useSelector.mockImplementation((selector) => selector({
-      products: given.products,
+      reducer: {
+        products: given.products,
+      },
     }));
   });
 

--- a/src/components/container/SignupFormContainer.jsx
+++ b/src/components/container/SignupFormContainer.jsx
@@ -16,9 +16,13 @@ import { get } from '../../utils';
 export default function SignupFormContainer() {
   const dispatch = useDispatch();
 
-  const { email, password } = useSelector(get('signupFields'));
-  const user = useSelector(get('user'));
-  const error = useSelector(get('error'));
+  const {
+    user,
+    error,
+    signupFields: {
+      email, password,
+    },
+  } = useSelector(get('reducer'));
 
   function handleChange({ name, value }) {
     dispatch(changeSignupField({ name, value }));

--- a/src/components/container/SignupFormContainer.test.jsx
+++ b/src/components/container/SignupFormContainer.test.jsx
@@ -14,12 +14,14 @@ describe('SignupFormContainer', () => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
     useSelector.mockImplementation((selector) => selector({
-      signupFields: {
-        email: 'test@test',
-        password: '1234',
+      reducer: {
+        signupFields: {
+          email: 'test@test',
+          password: '1234',
+        },
+        user: given.user,
+        error: given.error,
       },
-      user: given.user,
-      error: given.error,
     }));
   });
 

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -26,7 +26,9 @@ describe('HomePage', () => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
     useSelector.mockImplementation((selector) => selector({
-      products,
+      reducer: {
+        products,
+      },
     }));
   });
 

--- a/src/pages/LoginPage.test.jsx
+++ b/src/pages/LoginPage.test.jsx
@@ -13,13 +13,15 @@ jest.mock('react-redux');
 describe('LoginPage', () => {
   beforeEach(() => {
     useSelector.mockImplementation((selector) => selector({
-      loginFields: {
-        email: 'test@test',
-        password: '1234',
-      },
-      user: {
-        displayName: '',
-        uid: '',
+      reducer: {
+        loginFields: {
+          email: 'test@test',
+          password: '1234',
+        },
+        user: {
+          displayName: '',
+          uid: '',
+        },
       },
     }));
   });

--- a/src/pages/ProductPage.test.jsx
+++ b/src/pages/ProductPage.test.jsx
@@ -16,7 +16,9 @@ describe('ProductPage', () => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
     useSelector.mockImplementation((selector) => selector({
-      product: products[0],
+      reducer: {
+        product: products[0],
+      },
     }));
   });
 

--- a/src/pages/SignupPage.test.jsx
+++ b/src/pages/SignupPage.test.jsx
@@ -13,13 +13,15 @@ jest.mock('react-redux');
 describe('SignupPage', () => {
   beforeEach(() => {
     useSelector.mockImplementation((selector) => selector({
-      signupFields: {
-        email: 'test@test',
-        password: '1234',
-      },
-      user: {
-        displayName: '',
-        uid: '',
+      reducer: {
+        signupFields: {
+          email: 'test@test',
+          password: '1234',
+        },
+        user: {
+          displayName: '',
+          uid: '',
+        },
       },
     }));
   });

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { push } from 'connected-react-router';
 import { saveItem, deleteItem } from './services/storage';
 
 import {
@@ -117,13 +118,14 @@ export function loadProduct({ productId }) {
 
 export function requestLogin() {
   return async (dispatch, getState) => {
-    const { loginFields: { email, password } } = getState();
+    const { reducer: { loginFields: { email, password } } } = getState();
     try {
       const { user } = await postLogin({ email, password });
       const { displayName, uid } = user;
 
       dispatch(setUser({ displayName, uid }));
       saveItem('user', { displayName, uid });
+      dispatch(push('/'));
     } catch (error) {
       dispatch(setError(error.message));
     }
@@ -138,6 +140,7 @@ export function requestGoogleSignIn() {
 
       dispatch(setUser({ displayName, uid }));
       saveItem('user', { displayName, uid });
+      dispatch(push('/'));
     } catch (error) {
       dispatch(setError(error.message));
     }
@@ -146,12 +149,13 @@ export function requestGoogleSignIn() {
 
 export function requestSignup() {
   return async (dispatch, getState) => {
-    const { signupFields: { email, password } } = getState();
+    const { reducer: { signupFields: { email, password } } } = getState();
     try {
       const { user } = await postSignup({ email, password });
       const { displayName, uid } = user;
       dispatch(setUser({ displayName, uid }));
       saveItem('user', { displayName, uid });
+      dispatch(push('/'));
     } catch (error) {
       dispatch(setError(error.message));
     }

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -28,6 +28,7 @@ const middlewares = [...getDefaultMiddleware()];
 const mockStore = configureStore(middlewares);
 
 jest.mock('./services/api');
+jest.mock('connected-react-router');
 
 describe('reducer', () => {
   context('when previous state is undefined', () => {
@@ -247,9 +248,11 @@ describe('actions', () => {
   describe('requestLogin', () => {
     beforeEach(() => {
       store = mockStore({
-        loginFields: {
-          email: '',
-          password: '',
+        reducer: {
+          loginFields: {
+            email: '',
+            password: '',
+          },
         },
       });
     });
@@ -317,9 +320,11 @@ describe('actions', () => {
   describe('requestSignup', () => {
     beforeEach(() => {
       store = mockStore({
-        signupFields: {
-          email: '',
-          password: '',
+        reducer: {
+          signupFields: {
+            email: '',
+            password: '',
+          },
         },
       });
     });
@@ -354,9 +359,11 @@ describe('actions', () => {
   describe('requestLogout', () => {
     beforeEach(() => {
       store = mockStore({
-        user: {
-          displayName: 'tester',
-          uid: '123456',
+        reducer: {
+          user: {
+            displayName: 'tester',
+            uid: '123456',
+          },
         },
       });
     });


### PR DESCRIPTION
![redirect-homepage](https://user-images.githubusercontent.com/45390172/94990235-6ebc8480-05b5-11eb-9c84-0648b3a24b69.gif)

유저가 로그인하거나 회원가입에 성공하면 홈페이지로 redirect 하도록 함.

기존의 app 상태를 관리하면 reducer 값과 redux 내부에서 connected-react-router 를 사용하기 위해서 `connectRouter` 를 combine 하여 reducer가 두 개가 되었다. 

따라서 `useSelector` 로 상태값을 가져올 때 `utils` 에 정의한 `get` 함수에 객체의 key 값만 넣어서 가져오도록 하였는데, 이제는 두 리듀서가 하나의 큰 리듀서로 합쳐져서 `get('reducer')` 와 같이 전체 리듀서를 가져온 다음 밖에서 구조 분해 할당으로 원하는 상태값을 꺼내야 한다.

이 부분에 대한 리팩토링은 어떻게 해야 할지 고민중.