### PR TITLE
Render '판매하기' button in header if user logged in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import ProductPage from './pages/ProductPage';
 import { setUser } from './authSlice';
 
 import { loadItem } from './services/storage';
+import WritePage from './pages/WritePage';
 
 export default function App() {
   const dispatch = useDispatch();
@@ -34,6 +35,7 @@ export default function App() {
           <Route exact path="/login" component={LoginPage} />
           <Route exact path="/signup" component={SignupPage} />
           <Route path="/products/:id" component={ProductPage} />
+          <Route path="/newproduct" component={WritePage} />
           <Route component={NotFoundPage} />
         </Switch>
       </Layout.Main>

--- a/src/components/presentational/Header.jsx
+++ b/src/components/presentational/Header.jsx
@@ -1,7 +1,25 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { useSelector } from 'react-redux';
+
 import styled from '@emotion/styled';
+
+export default function Header() {
+  const user = useSelector((state) => state.authReducer.user);
+  return (
+    <Wrapper>
+      <Container>
+        <Link to="/">Kcena Market</Link>
+        <UserAuthBox>
+          {user.uid && <Link to="/newproduct">판매하기</Link>}
+          <Link to="/login">Log In</Link>
+          <Link to="/signup">Sign up</Link>
+        </UserAuthBox>
+      </Container>
+    </Wrapper>
+  );
+}
 
 const Wrapper = styled.header({
   fontFamily: 'Baloo, cursive',
@@ -40,17 +58,3 @@ const UserAuthBox = styled.div({
     paddingRight: '10px',
   },
 });
-
-export default function Header() {
-  return (
-    <Wrapper>
-      <Container>
-        <Link to="/">Kcena Market</Link>
-        <UserAuthBox>
-          <Link to="/login">Log In</Link>
-          <Link to="/signup">Sign up</Link>
-        </UserAuthBox>
-      </Container>
-    </Wrapper>
-  );
-}

--- a/src/components/presentational/Header.test.jsx
+++ b/src/components/presentational/Header.test.jsx
@@ -2,16 +2,70 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
+import { useSelector } from 'react-redux';
+
 import Header from './Header';
 
+jest.mock('react-redux');
+
 describe('Header', () => {
-  it('render title', () => {
-    const { container } = render((
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      authReducer: {
+        user: given.user,
+      },
+    }));
+  });
+
+  function renderHeader() {
+    return render((
       <MemoryRouter>
         <Header />
       </MemoryRouter>
     ));
+  }
 
-    expect(container).toHaveTextContent('Kcena Market');
+  context('with user uid', () => {
+    given('user', () => ({
+      displayName: 'tester',
+      uid: 'test1234',
+    }));
+
+    it('render title, Log In and Sign up', () => {
+      const controls = ['Kcena Market', 'Log In', 'Sign up'];
+      const { getByText } = renderHeader();
+
+      controls.forEach((control) => {
+        expect(getByText(control)).not.toBeNull();
+      });
+    });
+
+    it('render 판매하기', () => {
+      const { container } = renderHeader();
+
+      expect(container).toHaveTextContent('판매하기');
+    });
+  });
+
+  context('without user uid', () => {
+    given('user', () => ({
+      displayName: '',
+      uid: '',
+    }));
+
+    it('render title, Log In and Sign up', () => {
+      const controls = ['Kcena Market', 'Log In', 'Sign up'];
+      const { getByText } = renderHeader();
+
+      controls.forEach((control) => {
+        expect(getByText(control)).not.toBeNull();
+      });
+    });
+
+    it('doesn\'t render 판매하기', () => {
+      const { container } = renderHeader();
+
+      expect(container).not.toHaveTextContent('판매하기');
+    });
   });
 });

--- a/src/pages/WritePage.jsx
+++ b/src/pages/WritePage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function WritePage() {
+  return (
+    <>
+      <p>Write Page</p>
+    </>
+  );
+}

--- a/src/pages/WritePage.test.jsx
+++ b/src/pages/WritePage.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import WritePage from './WritePage';
+
+describe('WritePage', () => {
+  it('render', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <WritePage />
+      </MemoryRouter>
+    ));
+
+    expect(container).toHaveTextContent('Write Page');
+  });
+});


### PR DESCRIPTION
# 판매하기 버튼 렌더링 하기
![sals-button-render](https://user-images.githubusercontent.com/45390172/95648388-9493dd00-0b11-11eb-9f04-9ea27d32369d.gif)

유저가 로그인 하면 판매하기 버튼을 볼 수 있다. 이를 누르면 판매글을 쓸 수 있는 페이지로 이동 한다.