### PR TITLE
Revert to object.assign

### DIFF
--- a/src/components/container/WriteFormContainer.jsx
+++ b/src/components/container/WriteFormContainer.jsx
@@ -30,8 +30,7 @@ export default function WriteFormContainer() {
   function handleOnDrop(acceptedFiles) {
     setFiles([
       ...files,
-      ...acceptedFiles.map((file) => ({
-        ...file,
+      ...acceptedFiles.map((file) => Object.assign(file, {
         preview: URL.createObjectURL(file),
       })),
     ]);


### PR DESCRIPTION
#38 issue 로 인해 handleOnDrop 코드에서 디스트럭처링이 아닌 object.assign 코드로 되돌린다.