### PR TITLE
Apply material ui to login page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,6 +2430,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@reduxjs/toolkit": "^1.4.0",
     "connected-react-router": "^6.8.0",
     "facepaint": "^1.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import {
 
 import { useDispatch } from 'react-redux';
 
+import CssBaseline from '@material-ui/core/CssBaseline';
 import Header from './components/presentational/Header';
 import Layout from './styles/Layout';
 import HomePage from './pages/HomePage';
@@ -28,6 +29,7 @@ export default function App() {
 
   return (
     <Layout>
+      <CssBaseline />
       <Header />
       <Layout.Main>
         <Switch>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -75,15 +75,15 @@ describe('App', () => {
   it('navigates log in when you click the "log in"', () => {
     const { getByLabelText } = renderApp({ path: '/login' });
 
-    expect(getByLabelText('E-mail')).not.toBeNull();
-    expect(getByLabelText('Password')).not.toBeNull();
+    expect(getByLabelText(/E-mail/)).not.toBeNull();
+    expect(getByLabelText(/Password/)).not.toBeNull();
   });
 
   it('navigates Sign up when you click the "Sign up"', () => {
     const { getByLabelText } = renderApp({ path: '/signup' });
 
-    expect(getByLabelText('E-mail')).not.toBeNull();
-    expect(getByLabelText('Password')).not.toBeNull();
+    expect(getByLabelText(/E-mail/)).not.toBeNull();
+    expect(getByLabelText(/Password/)).not.toBeNull();
   });
 
   context('with invalid path', () => {

--- a/src/components/container/LoginFormContainer.test.jsx
+++ b/src/components/container/LoginFormContainer.test.jsx
@@ -36,8 +36,8 @@ describe('LoginFormContainer', () => {
         <LoginFormContainer />
       ));
 
-      expect(getByLabelText('E-mail').value).toBe('test@test');
-      expect(getByLabelText('Password').value).toBe('1234');
+      expect(getByLabelText(/E-mail/).value).toBe('test@test');
+      expect(getByLabelText(/Password/).value).toBe('1234');
     });
 
     it('listens change events', () => {
@@ -45,9 +45,9 @@ describe('LoginFormContainer', () => {
         <LoginFormContainer />
       ));
 
-      expect(getByLabelText('E-mail').value).toBe('test@test');
+      expect(getByLabelText(/E-mail/).value).toBe('test@test');
 
-      fireEvent.change(getByLabelText('E-mail'), {
+      fireEvent.change(getByLabelText(/E-mail/), {
         target: { value: 'new email' },
       });
 

--- a/src/components/presentational/LoginForm.jsx
+++ b/src/components/presentational/LoginForm.jsx
@@ -1,8 +1,19 @@
 import React from 'react';
 
+import {
+  TextField, Button, Box, InputAdornment,
+} from '@material-ui/core';
+
+import {
+  AccountCircle, LockRounded,
+} from '@material-ui/icons';
+
+import useStyles from '../../styles/styles';
+
 export default function LoginForm({
   fields, onChange, onSubmit, error, onGoogleSignIn,
 }) {
+  const classes = useStyles();
   const { email, password } = fields;
 
   function handleChange(event) {
@@ -11,43 +22,69 @@ export default function LoginForm({
   }
 
   return (
-    <>
+    <div className={classes.form}>
       <div>
         <p>{error}</p>
       </div>
-      <div>
-        <label htmlFor="login-email">E-mail</label>
-        <input
-          id="login-email"
-          type="email"
-          name="email"
-          value={email}
-          onChange={handleChange}
-        />
-      </div>
-
-      <div>
-        <label htmlFor="login-password">Password</label>
-        <input
-          id="login-password"
-          type="password"
-          name="password"
-          value={password}
-          onChange={handleChange}
-        />
-      </div>
-      <button
-        type="button"
-        onClick={onSubmit}
-      >
-        Log In
-      </button>
-      <button
-        type="button"
-        onClick={onGoogleSignIn}
-      >
-        Sign in with Google
-      </button>
-    </>
+      <TextField
+        type="email"
+        label="E-mail"
+        variant="outlined"
+        margin="normal"
+        required
+        fullWidth
+        id="email"
+        name="email"
+        value={email}
+        onChange={handleChange}
+        autoFocus
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <AccountCircle />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <TextField
+        type="password"
+        label="Password"
+        variant="outlined"
+        margin="normal"
+        required
+        fullWidth
+        id="password"
+        name="password"
+        value={password}
+        onChange={handleChange}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <LockRounded />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <Box clone my={1}>
+        <Button
+          variant="contained"
+          fullWidth
+          color="primary"
+          onClick={onSubmit}
+        >
+          Log In
+        </Button>
+      </Box>
+      <Box clone my={1}>
+        <Button
+          variant="contained"
+          fullWidth
+          color="secondary"
+          onClick={onGoogleSignIn}
+        >
+          Sign in with Google
+        </Button>
+      </Box>
+    </div>
   );
 }

--- a/src/components/presentational/LoginForm.test.jsx
+++ b/src/components/presentational/LoginForm.test.jsx
@@ -34,8 +34,8 @@ describe('LoginForm', () => {
     const { getByLabelText } = renderLoginForm({ email, password });
 
     const controls = [
-      { label: 'E-mail', value: email },
-      { label: 'Password', value: password },
+      { label: /E-mail/, value: email },
+      { label: /Password/, value: password },
     ];
 
     controls.forEach(({ label, value }) => {
@@ -48,8 +48,8 @@ describe('LoginForm', () => {
     const { getByLabelText } = renderLoginForm();
 
     const controls = [
-      { label: 'E-mail', name: 'email', value: 'tester@example.com' },
-      { label: 'Password', name: 'password', value: 'test' },
+      { label: /E-mail/, name: 'email', value: 'tester@example.com' },
+      { label: /Password/, name: 'password', value: 'test' },
     ];
 
     controls.forEach(({ label, name, value }) => {

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,12 +1,26 @@
 import React from 'react';
 
+import {
+  Typography, Container,
+} from '@material-ui/core';
+
+import useStyles from '../styles/styles';
+
 import LoginFormContainer from '../components/container/LoginFormContainer';
 
 export default function LoginPage() {
+  const classes = useStyles();
+
   return (
-    <div>
-      <h2>Log In</h2>
+    <Container
+      component="section"
+      maxWidth="xs"
+      className={classes.paper}
+    >
+      <Typography component="h2" variant="h4">
+        Log In
+      </Typography>
       <LoginFormContainer />
-    </div>
+    </Container>
   );
 }

--- a/src/pages/LoginPage.test.jsx
+++ b/src/pages/LoginPage.test.jsx
@@ -43,6 +43,6 @@ describe('LoginPage', () => {
       </MemoryRouter>
     ));
 
-    expect(getByLabelText('E-mail')).not.toBeNull();
+    expect(getByLabelText(/E-mail/)).not.toBeNull();
   });
 });

--- a/src/styles/Layout.jsx
+++ b/src/styles/Layout.jsx
@@ -25,6 +25,7 @@ Layout.Main = styled.section(mp({
   marginTop: '2rem',
   width: ['1024px', 'calc(100% - 2rem)', 'calc(100% - 1rem)'],
   position: 'relative',
+  height: '100vh',
   backgroundColor: '#fff',
 }));
 

--- a/src/styles/styles.jsx
+++ b/src/styles/styles.jsx
@@ -2,10 +2,10 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
-    marginTop: theme.spacing(1),
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    paddingTop: theme.spacing(8),
   },
   form: {
     width: '100%',

--- a/src/styles/styles.jsx
+++ b/src/styles/styles.jsx
@@ -1,0 +1,16 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    marginTop: theme.spacing(1),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  form: {
+    width: '100%',
+    marginTop: theme.spacing(1),
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
<img width="1084" alt="스크린샷 2020-10-26 오후 1 49 04" src="https://user-images.githubusercontent.com/45390172/97134883-07e45280-1792-11eb-8a85-fee01a238f77.png">
로그인 페이지를 꾸며 본다.

material ui docs에 나오는 `sign in templates` 를 참고하였음
source: [sign in template](https://material-ui.com/getting-started/templates/sign-in/)

[해당 포스트](https://www.daleseo.com/material-ui-text-fields/)를 참고하여 `TextField`에 이미지를 넣음.