### PR TITLE
Implement logout in the right menu of the header

### DIFF
--- a/src/components/container/LoginFormContainer.jsx
+++ b/src/components/container/LoginFormContainer.jsx
@@ -3,13 +3,11 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import LoginForm from '../presentational/LoginForm';
-import LogoutForm from '../presentational/LogoutForm';
 
 import {
   changeLoginField,
   requestLogin,
   requestGoogleSignIn,
-  requestLogout,
 } from '../../authSlice';
 
 import { get } from '../../utils';
@@ -18,7 +16,6 @@ export default function LoginFormContainer() {
   const dispatch = useDispatch();
 
   const {
-    user,
     error,
     loginFields: {
       email, password,
@@ -33,27 +30,17 @@ export default function LoginFormContainer() {
     dispatch(requestLogin());
   }
 
-  function handleClickLogout() {
-    dispatch(requestLogout());
-  }
-
   function handleSigninWithGoogle() {
     dispatch(requestGoogleSignIn());
   }
 
   return (
-    <>
-      {user.uid ? (
-        <LogoutForm onClick={handleClickLogout} />
-      ) : (
-        <LoginForm
-          fields={{ email, password }}
-          onChange={handleChange}
-          onSubmit={handleSubmit}
-          error={error}
-          onGoogleSignIn={handleSigninWithGoogle}
-        />
-      )}
-    </>
+    <LoginForm
+      fields={{ email, password }}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      error={error}
+      onGoogleSignIn={handleSigninWithGoogle}
+    />
   );
 }

--- a/src/components/container/LoginFormContainer.test.jsx
+++ b/src/components/container/LoginFormContainer.test.jsx
@@ -95,22 +95,4 @@ describe('LoginFormContainer', () => {
       expect(container).toHaveTextContent('Invaild');
     });
   });
-
-  context('when logged in', () => {
-    given('user', () => ({
-      displayName: 'tester',
-      uid: '123456',
-    }));
-
-    it('renders "Log out" button', () => {
-      const { getByText } = render((
-        <LoginFormContainer />
-      ));
-      expect(getByText('Log out')).not.toBeNull();
-
-      fireEvent.click(getByText('Log out'));
-
-      expect(dispatch).toBeCalled();
-    });
-  });
 });

--- a/src/components/container/RightHeaderMenuContainer.jsx
+++ b/src/components/container/RightHeaderMenuContainer.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import { requestLogout } from '../../authSlice';
+
+import RightHeaderMenu from '../presentational/RightHeaderMenu';
+
+export default function RightHeaderMenuContainer() {
+  const dispatch = useDispatch();
+
+  const user = useSelector((state) => state.authReducer.user);
+
+  function handleClickLogout() {
+    dispatch(requestLogout());
+  }
+
+  return (
+    <>
+      <RightHeaderMenu
+        user={user}
+        handleClickLogout={handleClickLogout}
+      />
+    </>
+  );
+}

--- a/src/components/container/RightHeaderMenuContainer.test.jsx
+++ b/src/components/container/RightHeaderMenuContainer.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import RightHeaderMenuContainer from './RightHeaderMenuContainer';
+
+jest.mock('react-redux');
+describe('RightHeaderMenuContainer', () => {
+  const dispatch = jest.fn();
+
+  function renderRightHeaderMenuContainer() {
+    return render((
+      <MemoryRouter>
+        <RightHeaderMenuContainer />
+      </MemoryRouter>
+    ));
+  }
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    useDispatch.mockImplementation(() => dispatch);
+    useSelector.mockImplementation((selector) => selector({
+      authReducer: {
+        user: given.user,
+      },
+    }));
+  });
+
+  context('with user', () => {
+    given('user', () => ({
+      displayName: 'tester',
+      uid: 'abc1234',
+    }));
+
+    it('render 판매하기, Log out', () => {
+      const { getByText } = renderRightHeaderMenuContainer();
+      expect(getByText('판매하기')).not.toBeNull();
+      expect(getByText('Log out')).not.toBeNull();
+    });
+
+    it('listen logout dispatch', () => {
+      const { getByText } = renderRightHeaderMenuContainer();
+
+      fireEvent.click(getByText('Log out'));
+
+      expect(dispatch).toBeCalled();
+    });
+  });
+});

--- a/src/components/container/SignupFormContainer.jsx
+++ b/src/components/container/SignupFormContainer.jsx
@@ -3,12 +3,10 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import SignupForm from '../presentational/SignupForm';
-import LogoutForm from '../presentational/LogoutForm';
 
 import {
   changeSignupField,
   requestSignup,
-  requestLogout,
 } from '../../authSlice';
 
 import { get } from '../../utils';
@@ -17,7 +15,6 @@ export default function SignupFormContainer() {
   const dispatch = useDispatch();
 
   const {
-    user,
     error,
     signupFields: {
       email, password,
@@ -32,22 +29,12 @@ export default function SignupFormContainer() {
     dispatch(requestSignup());
   }
 
-  function handleClickLogout() {
-    dispatch(requestLogout());
-  }
-
   return (
-    <>
-      {user.uid ? (
-        <LogoutForm onClick={handleClickLogout} />
-      ) : (
-        <SignupForm
-          fields={{ email, password }}
-          onChange={handleChange}
-          onSubmit={handleSubmit}
-          error={error}
-        />
-      )}
-    </>
+    <SignupForm
+      fields={{ email, password }}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      error={error}
+    />
   );
 }

--- a/src/components/container/SignupFormContainer.test.jsx
+++ b/src/components/container/SignupFormContainer.test.jsx
@@ -30,6 +30,7 @@ describe('SignupFormContainer', () => {
       displayName: '',
       uid: '',
     }));
+
     it('renders input controls', () => {
       const { getByLabelText } = render((
         <SignupFormContainer />
@@ -56,7 +57,7 @@ describe('SignupFormContainer', () => {
       });
     });
 
-    it('renders "Sign up" button', () => {
+    it('renders "Sign up" button and listen click event', () => {
       const { getByText } = render((
         <SignupFormContainer />
       ));
@@ -82,24 +83,6 @@ describe('SignupFormContainer', () => {
       fireEvent.click(getByText('Sign up'));
 
       expect(container).toHaveTextContent('Invaild');
-    });
-  });
-
-  context('when logged in', () => {
-    given('user', () => ({
-      displayName: 'tester',
-      uid: '123456',
-    }));
-
-    it('renders "Log out" button', () => {
-      const { getByText } = render((
-        <SignupFormContainer />
-      ));
-      expect(getByText('Log out')).not.toBeNull();
-
-      fireEvent.click(getByText('Log out'));
-
-      expect(dispatch).toBeCalled();
     });
   });
 });

--- a/src/components/presentational/Header.jsx
+++ b/src/components/presentational/Header.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { useSelector } from 'react-redux';
-
 import {
-  AppBar, Toolbar, Button, Typography, Container,
+  AppBar, Toolbar, Typography, Container,
 } from '@material-ui/core';
+
+import RightHeaderMenuContainer from '../container/RightHeaderMenuContainer';
 
 import useStyles from '../../styles/styles';
 
 export default function Header() {
-  const user = useSelector((state) => state.authReducer.user);
   const classes = useStyles();
 
   return (
@@ -19,7 +18,6 @@ export default function Header() {
         <Container maxWidth="lg">
           <Toolbar>
             <Typography
-              className={classes.title}
               color="inherit"
               component="h1"
               variant="h4"
@@ -27,18 +25,7 @@ export default function Header() {
               <Link to="/">Kcena Market</Link>
             </Typography>
             <div className={classes.grow} />
-            {user.uid
-            && (
-              <Button color="inherit">
-                <Link to="/newproduct">판매하기</Link>
-              </Button>
-            )}
-            <Button color="inherit">
-              <Link to="/login">Log In</Link>
-            </Button>
-            <Button color="inherit">
-              <Link to="/signup">Sign up</Link>
-            </Button>
+            <RightHeaderMenuContainer />
           </Toolbar>
         </Container>
       </AppBar>

--- a/src/components/presentational/Header.test.jsx
+++ b/src/components/presentational/Header.test.jsx
@@ -32,18 +32,12 @@ describe('Header', () => {
     }));
 
     it('render title, Log In and Sign up', () => {
-      const controls = ['Kcena Market', 'Log In', 'Sign up'];
+      const controls = ['Kcena Market', '판매하기', 'Log out'];
       const { getByText } = renderHeader();
 
       controls.forEach((control) => {
         expect(getByText(control)).not.toBeNull();
       });
-    });
-
-    it('render 판매하기', () => {
-      const { container } = renderHeader();
-
-      expect(container).toHaveTextContent('판매하기');
     });
   });
 

--- a/src/components/presentational/LogoutForm.jsx
+++ b/src/components/presentational/LogoutForm.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
+import { Button } from '@material-ui/core';
+
 export default function Logout({ onClick }) {
   return (
-    <div>
-      <button
-        type="button"
+    <>
+      <Button
+        color="inherit"
         onClick={onClick}
       >
         Log out
-      </button>
-    </div>
+      </Button>
+    </>
   );
 }

--- a/src/components/presentational/RightHeaderMenu.jsx
+++ b/src/components/presentational/RightHeaderMenu.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { Link } from 'react-router-dom';
+
+import { Button } from '@material-ui/core';
+
+import LogoutForm from './LogoutForm';
+
+export default function RightHeaderMenu({
+  user, handleClickLogout,
+}) {
+  return (
+    <>
+      {user.uid ? (
+        <>
+          <Button color="inherit">
+            <Link to="/newproduct">판매하기</Link>
+          </Button>
+          <LogoutForm onClick={handleClickLogout} />
+        </>
+      ) : (
+        <>
+          <Button color="inherit">
+            <Link to="/login">Log In</Link>
+          </Button>
+          <Button color="inherit">
+            <Link to="/signup">Sign up</Link>
+          </Button>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/presentational/RightHeaderMenu.test.jsx
+++ b/src/components/presentational/RightHeaderMenu.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import RightHeaderMenu from './RightHeaderMenu';
+
+describe('RightHeaderMenu', () => {
+  const handleClickLogout = jest.fn();
+
+  function renderRightHeaderMenu({ user }) {
+    return render((
+      <MemoryRouter>
+        <RightHeaderMenu
+          user={user}
+          handleClickLogout={handleClickLogout}
+        />
+      </MemoryRouter>
+    ));
+  }
+
+  context('with user uid', () => {
+    const user = {
+      displayName: 'tester',
+      uid: 'abc1234',
+    };
+
+    it('render 판매하기, Log out', () => {
+      const { getByText } = renderRightHeaderMenu({ user });
+
+      expect(getByText('판매하기')).not.toBeNull();
+      expect(getByText('Log out')).not.toBeNull();
+    });
+
+    it('listen logout event', () => {
+      const { getByText } = renderRightHeaderMenu({ user });
+
+      fireEvent.click(getByText('Log out'));
+
+      expect(handleClickLogout).toBeCalled();
+    });
+  });
+
+  context('without user uid', () => {
+    const user = {
+      displayName: '',
+      uid: '',
+    };
+
+    it('render Log In, Sign up', () => {
+      const { getByText } = renderRightHeaderMenu({ user });
+
+      expect(getByText('Log In')).not.toBeNull();
+      expect(getByText('Sign up')).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
![rightmenu-logout](https://user-images.githubusercontent.com/45390172/97802865-b7855d00-1c89-11eb-9adf-745a0d2ccf67.gif)

기존에는 로그인 페이지나 회원가입 페이지에서 로그아웃이 가능했는데, 로그인 하면 오른쪽 상단의 메뉴가 판매하기와 로그아웃 버튼으로 이루어지도록 수정하였다.