### PR TITLE
Apply formit to write page

### DIFF
--- a/src/components/container/WriteFormContainer.jsx
+++ b/src/components/container/WriteFormContainer.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { v4 as uuidv4 } from 'uuid';
 
@@ -9,7 +9,6 @@ import ImagesDropzone from '../presentational/ImagesDropzone';
 import ImagePreview from '../presentational/ImagePreview';
 
 import {
-  writeNewProduct,
   postProduct,
 } from '../../productSlice';
 
@@ -18,14 +17,8 @@ export default function WriteFormContainer() {
 
   const dispatch = useDispatch();
 
-  const newProduct = useSelector((state) => state.productReducer.newProduct);
-
-  function handleChange({ name, value }) {
-    dispatch(writeNewProduct({ name, value }));
-  }
-
-  function handleSubmit() {
-    dispatch(postProduct({ files }));
+  function handleSubmit({ newProduct }) {
+    dispatch(postProduct({ files, newProduct }));
     setFiles([]);
   }
 
@@ -61,8 +54,6 @@ export default function WriteFormContainer() {
         handleClickDeleteAllImage={handleDeleteAll}
       />
       <WriteForm
-        newProduct={newProduct}
-        onChange={handleChange}
         onSubmit={handleSubmit}
       />
     </div>

--- a/src/components/container/WriteFormContainer.test.jsx
+++ b/src/components/container/WriteFormContainer.test.jsx
@@ -1,61 +1,73 @@
 import React from 'react';
 
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import WriteFormContainer from './WriteFormContainer';
-
-import newProduct from '../../../fixtures/newProduct';
 
 jest.mock('react-redux');
 
 describe('WriteFormContainer', () => {
   const dispatch = jest.fn();
 
+  function renderWriteFormContainer() {
+    return render(<WriteFormContainer />);
+  }
+
   beforeEach(() => {
     dispatch.mockClear();
     useDispatch.mockImplementation(() => dispatch);
-    useSelector.mockImplementation((selector) => selector({
-      productReducer: {
-        newProduct,
-      },
-    }));
   });
 
-  function renderWriteFormContainer() {
-    return render(
-      <WriteFormContainer />,
-    );
-  }
+  context('when all forms are filled', () => {
+    it('possible submit event', async () => {
+      const { container } = renderWriteFormContainer();
 
-  it('renders input controls', () => {
-    const { getByLabelText } = renderWriteFormContainer();
+      const title = container.querySelector('input[name="title"]');
+      const description = container.querySelector('textarea[name="description"]');
+      const price = container.querySelector('input[name="price"]');
+      const region = container.querySelector('input[name="region"]');
 
-    expect(getByLabelText(/글 제목/).value).toBe(newProduct.title);
-    expect(getByLabelText(/게시글 내용을 작성해주세요/).value).toBe(newProduct.description);
-  });
+      await waitFor(() => {
+        fireEvent.change(title, {
+          target: {
+            value: '아이패드',
+          },
+        });
+      });
 
-  it('listens change events', () => {
-    const { getByLabelText } = renderWriteFormContainer();
+      await waitFor(() => {
+        fireEvent.change(description, {
+          target: {
+            value: '중고 아이패드 팝니다.',
+          },
+        });
+      });
 
-    expect(getByLabelText(/글 제목/).value).toBe(newProduct.title);
+      await waitFor(() => {
+        fireEvent.change(price, {
+          target: {
+            value: '1234',
+          },
+        });
+      });
 
-    fireEvent.change(getByLabelText(/글 제목/), {
-      target: { value: '핸드폰 팝니다.' },
+      await waitFor(() => {
+        fireEvent.change(region, {
+          target: {
+            value: '인천',
+          },
+        });
+      });
+
+      const submit = container.querySelector('button[type="submit"]');
+
+      await waitFor(() => {
+        fireEvent.click(submit);
+      });
+
+      expect(dispatch).toHaveBeenCalled();
     });
-
-    expect(dispatch).toBeCalledWith({
-      type: 'productSlice/writeNewProduct',
-      payload: { name: 'title', value: '핸드폰 팝니다.' },
-    });
-  });
-
-  it('listens submit event', () => {
-    const { getByText } = renderWriteFormContainer();
-
-    fireEvent.click(getByText('글쓰기'));
-
-    expect(dispatch).toBeCalled();
   });
 });

--- a/src/components/presentational/FormikField.jsx
+++ b/src/components/presentational/FormikField.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Field, ErrorMessage } from 'formik';
+import TextField from '@material-ui/core/TextField';
+
+export default function FormikField({
+  required = false,
+  id,
+  label,
+  name,
+  type = 'text',
+  error,
+  InputProps = {},
+  multiline = false,
+  rows = 0,
+  variant = 'standard',
+}) {
+  return (
+    <Field
+      autoComplete="off"
+      required={required}
+      id={id}
+      as={TextField}
+      label={label}
+      name={name}
+      fullWidth
+      type={type}
+      error={error}
+      helperText={<ErrorMessage name={name} />}
+      InputProps={InputProps}
+      multiline={multiline}
+      rows={rows}
+      variant={variant}
+    />
+  );
+}

--- a/src/components/presentational/ImagesDropzone.jsx
+++ b/src/components/presentational/ImagesDropzone.jsx
@@ -21,7 +21,7 @@ export default function ImagesDropzone({
               color="primary"
               align="center"
             >
-              Drag and drop some files here, or click to select files
+              상품 이미지를 드래그해서 올려주세요! 또는 클릭해서 파일을 선택해주세요!
             </Typography>
           </div>
         </section>

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -25,6 +25,13 @@ const validationSchema = yup.object({
     .required('필수 항목입니다'),
 });
 
+const initialValues = {
+  title: '',
+  description: '',
+  price: 0,
+  region: '',
+};
+
 export default function WriteForm({ onSubmit }) {
   const classes = useStyles();
 
@@ -34,12 +41,7 @@ export default function WriteForm({ onSubmit }) {
 
   return (
     <Formik
-      initialValues={{
-        title: '',
-        description: '',
-        price: 0,
-        region: '',
-      }}
+      initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -1,92 +1,122 @@
 import React from 'react';
 
+import { useFormik } from 'formik';
+import * as yup from 'yup';
+
 import {
   TextField, Button, Grid, InputAdornment,
 } from '@material-ui/core';
 import useStyles from '../../styles/styles';
 
-export default function WriteForm({ newProduct, onChange, onSubmit }) {
-  const classes = useStyles();
-  const {
-    title, description, price, region,
-  } = newProduct;
+const validationSchema = yup.object({
+  title: yup
+    .string()
+    .required('필수 항목입니다.'),
+  description: yup
+    .string()
+    .required('필수 항목입니다.'),
+  price: yup
+    .string()
+    .required('필수 항목입니다.'),
+  region: yup
+    .string()
+    .required('필수 항목입니다'),
+});
 
-  function handleChange(event) {
-    const { target: { name, value } } = event;
-    onChange({ name, value });
-  }
+export default function WriteForm({ onSubmit }) {
+  const classes = useStyles();
+
+  const formik = useFormik({
+    initialValues: {
+      title: '',
+      description: '',
+      price: 0,
+      region: '',
+    },
+    validationSchema,
+    onSubmit: () => onSubmit({ newProduct: formik.values }),
+  });
 
   return (
-    <Grid
-      container
-      spacing={3}
-      className={classes.form}
-    >
-      <Grid item xs={12}>
-        <TextField
-          type="text"
-          label="글 제목"
-          id="write-title"
-          name="title"
-          value={title}
-          onChange={handleChange}
-          fullWidth
-        />
-      </Grid>
-      <Grid item xs={6}>
-        <TextField
-          type="number"
-          label="상품 가격"
-          id="write-price"
-          name="price"
-          value={price}
-          onChange={handleChange}
-          fullWidth
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                ￦
-              </InputAdornment>
-            ),
-          }}
-        />
-      </Grid>
-      <Grid item xs={6}>
-        <TextField
-          type="text"
-          label="판매 지역"
-          id="write-region"
-          name="region"
-          value={region}
-          onChange={handleChange}
-          fullWidth
-        />
-      </Grid>
-      <Grid item xs={12}>
-        <TextField
-          type="text"
-          label="게시글 내용을 작성해주세요"
-          id="write-description"
-          name="description"
-          value={description}
-          onChange={handleChange}
-          multiline
-          rows={8}
-          variant="outlined"
-          fullWidth
-        />
-      </Grid>
-      <Grid item xs={12}>
-        <Button
-          type="submit"
-          variant="contained"
-          onClick={onSubmit}
-          fullWidth
-        >
-          글쓰기
-        </Button>
+    <form onSubmit={formik.handleSubmit}>
+      <Grid
+        container
+        spacing={3}
+        className={classes.form}
+      >
+        <Grid item xs={12}>
+          <TextField
+            type="text"
+            label="글 제목"
+            id="write-title"
+            name="title"
+            value={formik.values.title}
+            onChange={formik.handleChange}
+            error={formik.touched.title && Boolean(formik.errors.title)}
+            helperText={formik.touched.title && formik.errors.title}
+            fullWidth
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            type="number"
+            label="상품 가격"
+            id="write-price"
+            name="price"
+            value={formik.values.price}
+            onChange={formik.handleChange}
+            error={formik.touched.price && Boolean(formik.errors.price)}
+            helperText={formik.touched.price && formik.errors.price}
+            fullWidth
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  ￦
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            type="text"
+            label="판매 지역"
+            id="write-region"
+            name="region"
+            value={formik.values.region}
+            onChange={formik.handleChange}
+            error={formik.touched.region && Boolean(formik.errors.region)}
+            helperText={formik.touched.region && formik.errors.region}
+            fullWidth
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            type="text"
+            label="게시글 내용을 작성해주세요"
+            id="write-description"
+            name="description"
+            value={formik.values.description}
+            onChange={formik.handleChange}
+            error={formik.touched.description && Boolean(formik.errors.description)}
+            helperText={formik.touched.description && formik.errors.description}
+            multiline
+            rows={8}
+            variant="outlined"
+            fullWidth
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
+          >
+            글쓰기
+          </Button>
 
+        </Grid>
       </Grid>
-    </Grid>
+    </form>
   );
 }

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -50,6 +50,7 @@ export default function WriteForm({ onSubmit }) {
             label="글 제목"
             id="write-title"
             name="title"
+            required
             value={formik.values.title}
             onChange={formik.handleChange}
             error={formik.touched.title && Boolean(formik.errors.title)}
@@ -63,6 +64,7 @@ export default function WriteForm({ onSubmit }) {
             label="상품 가격"
             id="write-price"
             name="price"
+            required
             value={formik.values.price}
             onChange={formik.handleChange}
             error={formik.touched.price && Boolean(formik.errors.price)}
@@ -83,6 +85,7 @@ export default function WriteForm({ onSubmit }) {
             label="판매 지역"
             id="write-region"
             name="region"
+            required
             value={formik.values.region}
             onChange={formik.handleChange}
             error={formik.touched.region && Boolean(formik.errors.region)}
@@ -96,6 +99,7 @@ export default function WriteForm({ onSubmit }) {
             label="게시글 내용을 작성해주세요"
             id="write-description"
             name="description"
+            required
             value={formik.values.description}
             onChange={formik.handleChange}
             error={formik.touched.description && Boolean(formik.errors.description)}

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -65,7 +65,7 @@ export default function WriteForm({ onSubmit }) {
                   label="상품 가격"
                   id="write-price"
                   name="price"
-                  error={touched.description && Boolean(errors.description)}
+                  error={touched.price && Boolean(errors.price)}
                   InputProps={{
                     startAdornment: (
                       <InputAdornment position="start">

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -50,7 +50,6 @@ export default function WriteForm({ onSubmit }) {
             label="글 제목"
             id="write-title"
             name="title"
-            required
             value={formik.values.title}
             onChange={formik.handleChange}
             error={formik.touched.title && Boolean(formik.errors.title)}
@@ -64,7 +63,6 @@ export default function WriteForm({ onSubmit }) {
             label="상품 가격"
             id="write-price"
             name="price"
-            required
             value={formik.values.price}
             onChange={formik.handleChange}
             error={formik.touched.price && Boolean(formik.errors.price)}
@@ -85,7 +83,6 @@ export default function WriteForm({ onSubmit }) {
             label="판매 지역"
             id="write-region"
             name="region"
-            required
             value={formik.values.region}
             onChange={formik.handleChange}
             error={formik.touched.region && Boolean(formik.errors.region)}
@@ -99,7 +96,6 @@ export default function WriteForm({ onSubmit }) {
             label="게시글 내용을 작성해주세요"
             id="write-description"
             name="description"
-            required
             value={formik.values.description}
             onChange={formik.handleChange}
             error={formik.touched.description && Boolean(formik.errors.description)}

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
-import { useFormik } from 'formik';
+import { Formik, Form } from 'formik';
 import * as yup from 'yup';
 
 import {
-  TextField, Button, Grid, InputAdornment,
+  Button, Grid, InputAdornment,
 } from '@material-ui/core';
+import FormikField from './FormikField';
+
 import useStyles from '../../styles/styles';
 
 const validationSchema = yup.object({
@@ -26,97 +28,85 @@ const validationSchema = yup.object({
 export default function WriteForm({ onSubmit }) {
   const classes = useStyles();
 
-  const formik = useFormik({
-    initialValues: {
-      title: '',
-      description: '',
-      price: 0,
-      region: '',
-    },
-    validationSchema,
-    onSubmit: () => onSubmit({ newProduct: formik.values }),
-  });
+  function handleSubmit(values) {
+    onSubmit({ newProduct: values });
+  }
 
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <Grid
-        container
-        spacing={3}
-        className={classes.form}
-      >
-        <Grid item xs={12}>
-          <TextField
-            type="text"
-            label="글 제목"
-            id="write-title"
-            name="title"
-            value={formik.values.title}
-            onChange={formik.handleChange}
-            error={formik.touched.title && Boolean(formik.errors.title)}
-            helperText={formik.touched.title && formik.errors.title}
-            fullWidth
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <TextField
-            type="number"
-            label="상품 가격"
-            id="write-price"
-            name="price"
-            value={formik.values.price}
-            onChange={formik.handleChange}
-            error={formik.touched.price && Boolean(formik.errors.price)}
-            helperText={formik.touched.price && formik.errors.price}
-            fullWidth
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  ￦
-                </InputAdornment>
-              ),
-            }}
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <TextField
-            type="text"
-            label="판매 지역"
-            id="write-region"
-            name="region"
-            value={formik.values.region}
-            onChange={formik.handleChange}
-            error={formik.touched.region && Boolean(formik.errors.region)}
-            helperText={formik.touched.region && formik.errors.region}
-            fullWidth
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            type="text"
-            label="게시글 내용을 작성해주세요"
-            id="write-description"
-            name="description"
-            value={formik.values.description}
-            onChange={formik.handleChange}
-            error={formik.touched.description && Boolean(formik.errors.description)}
-            helperText={formik.touched.description && formik.errors.description}
-            multiline
-            rows={8}
-            variant="outlined"
-            fullWidth
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <Button
-            type="submit"
-            variant="contained"
-            fullWidth
-          >
-            글쓰기
-          </Button>
-
-        </Grid>
-      </Grid>
-    </form>
+    <Formik
+      initialValues={{
+        title: '',
+        description: '',
+        price: 0,
+        region: '',
+      }}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
+    >
+      {
+        ({ touched, errors }) => (
+          <Form>
+            <Grid
+              container
+              spacing={3}
+              className={classes.form}
+            >
+              <Grid item xs={12}>
+                <FormikField
+                  label="글 제목"
+                  id="write-title"
+                  name="title"
+                  error={touched.title && Boolean(errors.title)}
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <FormikField
+                  type="number"
+                  label="상품 가격"
+                  id="write-price"
+                  name="price"
+                  error={touched.description && Boolean(errors.description)}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        ￦
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <FormikField
+                  label="판매 지역"
+                  id="write-region"
+                  name="region"
+                  error={touched.region && Boolean(errors.region)}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <FormikField
+                  label="게시글 내용을 작성해주세요"
+                  id="write-description"
+                  name="description"
+                  error={touched.description && Boolean(errors.description)}
+                  multiline
+                  rows={8}
+                  variant="outlined"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  fullWidth
+                >
+                  글쓰기
+                </Button>
+              </Grid>
+            </Grid>
+          </Form>
+        )
+      }
+    </Formik>
   );
 }

--- a/src/productSlice.js
+++ b/src/productSlice.js
@@ -7,21 +7,11 @@ import {
   uploadProductImages,
 } from './services/api';
 
-const initialStateNewProduct = {
-  title: '',
-  description: '',
-  price: '',
-  region: '',
-};
-
 const { actions, reducer: productReducer } = createSlice({
   name: 'productSlice',
   initialState: {
     product: null,
     products: [],
-    newProduct: {
-      ...initialStateNewProduct,
-    },
   },
   reducers: {
     setProducts(state, { payload: products }) {
@@ -34,23 +24,6 @@ const { actions, reducer: productReducer } = createSlice({
       return {
         ...state,
         product,
-      };
-    },
-    writeNewProduct(state, { payload: { name, value } }) {
-      return {
-        ...state,
-        newProduct: {
-          ...state.newProduct,
-          [name]: value,
-        },
-      };
-    },
-    initialNewProduct(state) {
-      return {
-        ...state,
-        newProduct: {
-          ...initialStateNewProduct,
-        },
       };
     },
   },
@@ -77,16 +50,13 @@ export function loadProduct({ productId }) {
   };
 }
 
-export function postProduct({ files }) {
-  return async (dispatch, getState) => {
+export function postProduct({ files, newProduct }) {
+  return async (_, getState) => {
     const {
       authReducer: {
         user: {
           uid,
         },
-      },
-      productReducer: {
-        newProduct,
       },
     } = getState();
 
@@ -100,8 +70,6 @@ export function postProduct({ files }) {
       creatorId: uid,
       createAt: Date.now(),
     });
-
-    dispatch(initialNewProduct());
   };
 }
 

--- a/src/productSlice.test.js
+++ b/src/productSlice.test.js
@@ -7,11 +7,10 @@ import productReducer, {
   postProduct,
   setProduct,
   setProducts,
-  writeNewProduct,
-  initialNewProduct,
 } from './productSlice';
 
 import products from '../fixtures/products';
+import newProduct from '../fixtures/newProduct';
 
 const middlewares = [...getDefaultMiddleware()];
 const mockStore = configureStore(middlewares);
@@ -23,12 +22,6 @@ describe('productReducer', () => {
     const initialState = {
       product: null,
       products: [],
-      newProduct: {
-        title: '',
-        description: '',
-        price: '',
-        region: '',
-      },
     };
 
     it('returns initialState', () => {
@@ -61,67 +54,6 @@ describe('productReducer', () => {
 
     expect(state.product.id).toBe(1);
     expect(state.product.title).toBe('크리넥스 KF-AD 소형 마스크 팝니다.');
-  });
-
-  describe('writeNewProduct', () => {
-    context('when title is changed', () => {
-      const initialState = {
-        newProduct: {
-          title: 'old title',
-          description: '아이패드 3세대 12인치 256기가 팝니다.',
-          price: '10000',
-          region: '인천',
-        },
-      };
-
-      it('change title', () => {
-        const state = productReducer(initialState, writeNewProduct({
-          name: 'title',
-          value: 'new title',
-        }));
-
-        expect(state.newProduct.title).toBe('new title');
-        expect(state.newProduct.description).toBe('아이패드 3세대 12인치 256기가 팝니다.');
-      });
-    });
-
-    context('when description is changed', () => {
-      const initialState = {
-        newProduct: {
-          title: '아이패드',
-          description: 'old description',
-          price: '10000',
-          region: '인천',
-        },
-      };
-
-      it('change description', () => {
-        const state = productReducer(initialState, writeNewProduct({
-          name: 'description',
-          value: 'new description',
-        }));
-
-        expect(state.newProduct.title).toBe('아이패드');
-        expect(state.newProduct.description).toBe('new description');
-      });
-    });
-  });
-
-  describe('initialNewProduct', () => {
-    it('initialization new product field', () => {
-      const initialState = {
-        newProduct: {
-          title: '아이패드',
-          description: 'old description',
-          price: '10000',
-          region: '인천',
-        },
-      };
-
-      const state = productReducer(initialState, initialNewProduct());
-
-      expect(state.newProduct.title).toBe('');
-    });
   });
 });
 
@@ -164,23 +96,13 @@ describe('actions', () => {
             uid: '1234',
           },
         },
-        productReducer: {
-          newProduct: {
-            title: 'iPhone',
-            description: '팝니다.',
-          },
-        },
       });
     });
 
     it('dispatchs', async () => {
       const files = [];
 
-      await store.dispatch(postProduct({ files }));
-
-      const actions = store.getActions();
-
-      expect(actions[0]).toEqual(initialNewProduct());
+      await store.dispatch(postProduct({ files, newProduct }));
     });
   });
 });


### PR DESCRIPTION
![writepage_validation](https://user-images.githubusercontent.com/45390172/99180263-0641f500-2768-11eb-9b7e-2dc221431a3e.gif)

WriteForm에 formik을 적용한다.
- material ui에서 `<TextField>`는 `required` 속성이 `<form>` 태그 안에 있을 때 동작함을 알게 되었다. 이 속성이 없이 글쓰기 버튼을 눌렀을 때는 빨갛게 에러로 처리되었는데, 속성을 추가하니 말풍선 처럼 작은 창이 뜨면서 입력하라는 문구가 나타났다.
- `formik`을 사용하니 form의 validation 처리가 매우 편리했다. 기존에 redux로 관리하던 새 상품 페이지 form의 state는 모두 삭제되었다. 그래서 `writeFormContainer` 컴포넌트 테스트가 어떻게 이루어져야 할지 고민이다.
- `writeForm` 컴포넌트의 테스트에서 form의 input 값들을 controls로 모아 forEach를 돌려 중복되지 않도록 테스트 하고 싶었는데, 내부에서 `await waitFor`를 사용하는게 문제인지 테스트에서 submit 버튼에 따라 호출되는 매개변수가 여러개로 나타났다. 그래서 지금처럼 나열하는 식으로 일단 테스트를 진행했다.

source
- [How to test a formik component with React Testing Library](https://medium.com/@thexap/how-to-test-a-formik-component-with-react-testing-library-a5584fcfc03f)
- [React forms with Formik and Unit Testing with react-testing-library](https://hackernoon.com/react-forms-with-formik-and-unit-testing-with-react-testing-library-j0b32c9)