### PR TITLE
Implement confirm dialog

### DIFF
--- a/src/components/container/LoggedInUserSellProductsContainer.jsx
+++ b/src/components/container/LoggedInUserSellProductsContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -6,7 +6,6 @@ import {
   loadLoggedInUserSellProducts,
   deleteProduct,
 } from '../../productSlice';
-import ConfirmDialog from '../presentational/ConfirmDialog';
 
 import TableForm from '../presentational/TableForm';
 
@@ -17,38 +16,22 @@ const columns = [
 
 export default function LoggedInUserSellProductsContainer({ user }) {
   const dispatch = useDispatch();
-  const [confirmDialog, setConfirmDialog] = useState({
-    isOpen: false,
-    title: '',
-    content: '',
-  });
 
   useEffect(() => {
     dispatch(loadLoggedInUserSellProducts({ user }));
   }, []);
 
   function handleDeleteProduct(product) {
-    setConfirmDialog({
-      isOpen: true,
-      title: '상품을 삭제하시겠습니까?',
-      content: '삭제하면 되돌릴 수 없습니다.',
-      onConfirm: () => dispatch(deleteProduct({ product })),
-    });
+    dispatch(deleteProduct({ product }));
   }
 
   const userProducts = useSelector((state) => state.productReducer.loggedInUserSellProducts);
 
   return (
-    <>
-      <TableForm
-        columns={columns}
-        products={userProducts}
-        handleDeleteProduct={handleDeleteProduct}
-      />
-      <ConfirmDialog
-        confirmDialog={confirmDialog}
-        setConfirmDialog={setConfirmDialog}
-      />
-    </>
+    <TableForm
+      columns={columns}
+      products={userProducts}
+      handleDeleteProduct={handleDeleteProduct}
+    />
   );
 }

--- a/src/components/container/LoggedInUserSellProductsContainer.jsx
+++ b/src/components/container/LoggedInUserSellProductsContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -6,6 +6,7 @@ import {
   loadLoggedInUserSellProducts,
   deleteProduct,
 } from '../../productSlice';
+import ConfirmDialog from '../presentational/ConfirmDialog';
 
 import TableForm from '../presentational/TableForm';
 
@@ -16,22 +17,38 @@ const columns = [
 
 export default function LoggedInUserSellProductsContainer({ user }) {
   const dispatch = useDispatch();
+  const [confirmDialog, setConfirmDialog] = useState({
+    isOpen: false,
+    title: '',
+    content: '',
+  });
 
   useEffect(() => {
     dispatch(loadLoggedInUserSellProducts({ user }));
   }, []);
 
   function handleDeleteProduct(product) {
-    dispatch(deleteProduct({ product }));
+    setConfirmDialog({
+      isOpen: true,
+      title: '상품을 삭제하시겠습니까?',
+      content: '삭제하면 되돌릴 수 없습니다.',
+      onConfirm: () => dispatch(deleteProduct({ product })),
+    });
   }
 
   const userProducts = useSelector((state) => state.productReducer.loggedInUserSellProducts);
 
   return (
-    <TableForm
-      columns={columns}
-      products={userProducts}
-      handleDeleteProduct={handleDeleteProduct}
-    />
+    <>
+      <TableForm
+        columns={columns}
+        products={userProducts}
+        handleDeleteProduct={handleDeleteProduct}
+      />
+      <ConfirmDialog
+        confirmDialog={confirmDialog}
+        setConfirmDialog={setConfirmDialog}
+      />
+    </>
   );
 }

--- a/src/components/container/LoggedInUserSellProductsContainer.test.jsx
+++ b/src/components/container/LoggedInUserSellProductsContainer.test.jsx
@@ -7,15 +7,25 @@ import { useDispatch, useSelector } from 'react-redux';
 import LoggedInUserSellProductsContainer from './LoggedInUserSellProductsContainer';
 
 import loggedInUserSellProducts from '../../../fixtures/loggedInUserSellProducts';
+import ConfirmationContext from '../../contexts/ConfirmationContext';
 
 jest.mock('react-redux');
 
 describe('LoggedInUserSellProductsContainer', () => {
   const dispatch = jest.fn();
+  const showConfirmation = jest.fn();
+  const setConfirmForm = jest.fn();
 
   function renderLoggedInUserSellProductsContainer() {
     return render((
-      <LoggedInUserSellProductsContainer />
+      <ConfirmationContext.Provider
+        value={{
+          showConfirmation,
+          setConfirmForm,
+        }}
+      >
+        <LoggedInUserSellProductsContainer />
+      </ConfirmationContext.Provider>
     ));
   }
 
@@ -27,6 +37,7 @@ describe('LoggedInUserSellProductsContainer', () => {
         loggedInUserSellProducts,
       },
     }));
+    showConfirmation.mockResolvedValue(() => true);
   });
 
   it('render products', () => {

--- a/src/components/presentational/ConfirmDialog.jsx
+++ b/src/components/presentational/ConfirmDialog.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+export default function ConfirmDialog({
+  confirmDialog, setConfirmDialog,
+}) {
+  const {
+    isOpen, title, content, onConfirm,
+  } = confirmDialog;
+
+  function onClose() {
+    setConfirmDialog({
+      ...confirmDialog,
+      isOpen: false,
+    });
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      aria-labelledby="confirm-dialog"
+    >
+      <DialogTitle id="confirm-dialog">{title}</DialogTitle>
+      <DialogContent>{content}</DialogContent>
+      <DialogActions>
+        <Button
+          variant="contained"
+          onClick={onClose}
+          color="default"
+        >
+          NO
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onConfirm();
+            onClose();
+          }}
+          color="secondary"
+        >
+          YES
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/presentational/ConfirmDialog.jsx
+++ b/src/components/presentational/ConfirmDialog.jsx
@@ -6,23 +6,12 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
 export default function ConfirmDialog({
-  confirmDialog, setConfirmDialog,
+  isOpen, title, content, onConfirm, onCancel,
 }) {
-  const {
-    isOpen, title, content, onConfirm,
-  } = confirmDialog;
-
-  function onClose() {
-    setConfirmDialog({
-      ...confirmDialog,
-      isOpen: false,
-    });
-  }
-
   return (
     <Dialog
       open={isOpen}
-      onClose={onClose}
+      onClose={onCancel}
       aria-labelledby="confirm-dialog"
     >
       <DialogTitle id="confirm-dialog">{title}</DialogTitle>
@@ -30,17 +19,14 @@ export default function ConfirmDialog({
       <DialogActions>
         <Button
           variant="contained"
-          onClick={onClose}
+          onClick={onCancel}
           color="default"
         >
           NO
         </Button>
         <Button
           variant="contained"
-          onClick={() => {
-            onConfirm();
-            onClose();
-          }}
+          onClick={onConfirm}
           color="secondary"
         >
           YES

--- a/src/components/presentational/ConfirmDialog.test.jsx
+++ b/src/components/presentational/ConfirmDialog.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import ConfirmDialog from './ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const setConfirmDialog = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  function renderConfirmDialog({ confirmDialog }) {
+    return render((
+      <ConfirmDialog
+        confirmDialog={confirmDialog}
+        setConfirmDialog={setConfirmDialog}
+      />
+    ));
+  }
+
+  beforeEach(() => {
+    setConfirmDialog.mockClear();
+    mockOnConfirm.mockClear();
+  });
+
+  context('Dialog is opened', () => {
+    const openConfirmDialog = {
+      isOpen: true,
+      title: '삭제하시겠습니까?',
+      content: '삭제하면 되돌릴 수 없습니다.',
+      onConfirm: mockOnConfirm,
+    };
+
+    it('render title and content', async () => {
+      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+
+      const title = await waitFor(() => getByText(openConfirmDialog.title));
+      const content = await waitFor(() => getByText(openConfirmDialog.content));
+
+      expect(title).toHaveTextContent(openConfirmDialog.title);
+      expect(content).toHaveTextContent(openConfirmDialog.content);
+    });
+
+    it('render button', async () => {
+      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+
+      const yes = await waitFor(() => getByText('YES'));
+      const no = await waitFor(() => getByText('NO'));
+
+      expect(yes).not.toBeNull();
+      expect(no).not.toBeNull();
+    });
+
+    it('listens close event', async () => {
+      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+
+      const no = await waitFor(() => getByText('NO'));
+
+      fireEvent.click(no);
+
+      expect(setConfirmDialog).toBeCalledWith({
+        ...openConfirmDialog,
+        isOpen: false,
+      });
+    });
+
+    it('listens onConfirm event', async () => {
+      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+
+      const yes = await waitFor(() => getByText('YES'));
+
+      fireEvent.click(yes);
+
+      expect(mockOnConfirm).toBeCalled();
+    });
+  });
+
+  context('Dialog is not opened', () => {
+    const closeConfirmDialog = {
+      isOpen: false,
+      title: '',
+      content: '',
+    };
+
+    it('doesn\'t render confirm dialog', async () => {
+      const { container } = renderConfirmDialog({ confirmDialog: closeConfirmDialog });
+
+      expect(container).not.toHaveTextContent('YES');
+      expect(container).not.toHaveTextContent('NO');
+    });
+  });
+});

--- a/src/components/presentational/ConfirmDialog.test.jsx
+++ b/src/components/presentational/ConfirmDialog.test.jsx
@@ -5,21 +5,26 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import ConfirmDialog from './ConfirmDialog';
 
 describe('ConfirmDialog', () => {
-  const setConfirmDialog = jest.fn();
-  const mockOnConfirm = jest.fn();
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
 
-  function renderConfirmDialog({ confirmDialog }) {
+  function renderConfirmDialog({
+    isOpen, title, content, onConfirm, onCancel,
+  }) {
     return render((
       <ConfirmDialog
-        confirmDialog={confirmDialog}
-        setConfirmDialog={setConfirmDialog}
+        isOpen={isOpen}
+        title={title}
+        content={content}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
       />
     ));
   }
 
   beforeEach(() => {
-    setConfirmDialog.mockClear();
-    mockOnConfirm.mockClear();
+    onConfirm.mockClear();
+    onCancel.mockClear();
   });
 
   context('Dialog is opened', () => {
@@ -27,11 +32,12 @@ describe('ConfirmDialog', () => {
       isOpen: true,
       title: '삭제하시겠습니까?',
       content: '삭제하면 되돌릴 수 없습니다.',
-      onConfirm: mockOnConfirm,
+      onConfirm,
+      onCancel,
     };
 
     it('render title and content', async () => {
-      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+      const { getByText } = renderConfirmDialog(openConfirmDialog);
 
       const title = await waitFor(() => getByText(openConfirmDialog.title));
       const content = await waitFor(() => getByText(openConfirmDialog.content));
@@ -41,7 +47,7 @@ describe('ConfirmDialog', () => {
     });
 
     it('render button', async () => {
-      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+      const { getByText } = renderConfirmDialog(openConfirmDialog);
 
       const yes = await waitFor(() => getByText('YES'));
       const no = await waitFor(() => getByText('NO'));
@@ -51,26 +57,23 @@ describe('ConfirmDialog', () => {
     });
 
     it('listens close event', async () => {
-      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+      const { getByText } = renderConfirmDialog(openConfirmDialog);
 
       const no = await waitFor(() => getByText('NO'));
 
       fireEvent.click(no);
 
-      expect(setConfirmDialog).toBeCalledWith({
-        ...openConfirmDialog,
-        isOpen: false,
-      });
+      expect(onCancel).toBeCalled();
     });
 
     it('listens onConfirm event', async () => {
-      const { getByText } = renderConfirmDialog({ confirmDialog: openConfirmDialog });
+      const { getByText } = renderConfirmDialog(openConfirmDialog);
 
       const yes = await waitFor(() => getByText('YES'));
 
       fireEvent.click(yes);
 
-      expect(mockOnConfirm).toBeCalled();
+      expect(onConfirm).toBeCalled();
     });
   });
 
@@ -79,10 +82,12 @@ describe('ConfirmDialog', () => {
       isOpen: false,
       title: '',
       content: '',
+      onConfirm,
+      onCancel,
     };
 
     it('doesn\'t render confirm dialog', async () => {
-      const { container } = renderConfirmDialog({ confirmDialog: closeConfirmDialog });
+      const { container } = renderConfirmDialog(closeConfirmDialog);
 
       expect(container).not.toHaveTextContent('YES');
       expect(container).not.toHaveTextContent('NO');

--- a/src/components/presentational/ConfirmDialog.test.jsx
+++ b/src/components/presentational/ConfirmDialog.test.jsx
@@ -5,9 +5,6 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import ConfirmDialog from './ConfirmDialog';
 
 describe('ConfirmDialog', () => {
-  const onConfirm = jest.fn();
-  const onCancel = jest.fn();
-
   function renderConfirmDialog({
     isOpen, title, content, onConfirm, onCancel,
   }) {
@@ -21,6 +18,9 @@ describe('ConfirmDialog', () => {
       />
     ));
   }
+
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
 
   beforeEach(() => {
     onConfirm.mockClear();

--- a/src/components/presentational/DeleteButton.jsx
+++ b/src/components/presentational/DeleteButton.jsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+
+import Button from '@material-ui/core/Button';
+
+import ConfirmationContext from '../../contexts/ConfirmationContext';
+
+const DeleteButton = ({ onClickDelete }) => {
+  const { showConfirmation, setConfirmForm } = useContext(ConfirmationContext);
+
+  const handleOnClick = async () => {
+    setConfirmForm({
+      title: '삭제하시겠습니까?',
+      content: '삭제하면 되돌릴 수 없습니다.',
+    });
+
+    const result = await showConfirmation();
+
+    if (result) {
+      onClickDelete();
+    }
+  };
+
+  return (
+    <Button
+      size="small"
+      variant="contained"
+      color="secondary"
+      onClick={handleOnClick}
+    >
+      Delete
+    </Button>
+  );
+};
+
+export default DeleteButton;

--- a/src/components/presentational/DeleteButton.test.jsx
+++ b/src/components/presentational/DeleteButton.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import ConfirmationContext from '../../contexts/ConfirmationContext';
+
+import DeleteButton from './DeleteButton';
+
+describe('DeleteButton', () => {
+  const onClickDelete = jest.fn();
+  const setConfirmForm = jest.fn();
+  const showConfirmation = jest.fn();
+
+  function renderDeleteButton() {
+    return render((
+      <ConfirmationContext.Provider
+        value={{
+          showConfirmation,
+          setConfirmForm,
+        }}
+      >
+        <DeleteButton
+          onClickDelete={onClickDelete}
+        />
+      </ConfirmationContext.Provider>
+    ));
+  }
+
+  beforeEach(() => {
+    onClickDelete.mockClear();
+    setConfirmForm.mockClear();
+  });
+
+  it('render delete button', () => {
+    const { container } = renderDeleteButton();
+
+    expect(container).toHaveTextContent('Delete');
+  });
+
+  context('when user clicked "YES"', () => {
+    it('call onClickDelete', async () => {
+      showConfirmation.mockImplementation(() => (
+        Promise.resolve(true)
+      ));
+
+      const { container } = renderDeleteButton();
+
+      const deleteButton = container.querySelector('button[type="button"]');
+
+      fireEvent.click(deleteButton);
+
+      expect(setConfirmForm).toBeCalledWith({
+        title: '삭제하시겠습니까?',
+        content: '삭제하면 되돌릴 수 없습니다.',
+      });
+      expect(showConfirmation).toBeCalled();
+      await waitFor(() => expect(onClickDelete).toBeCalled());
+    });
+  });
+
+  context('when user clicked "NO"', () => {
+    it('doesn\'t call onClickDelete', async () => {
+      showConfirmation.mockImplementation(() => (
+        Promise.resolve(false)
+      ));
+
+      const { container } = renderDeleteButton();
+
+      const deleteButton = container.querySelector('button[type="button"]');
+
+      fireEvent.click(deleteButton);
+
+      expect(setConfirmForm).toBeCalledWith({
+        title: '삭제하시겠습니까?',
+        content: '삭제하면 되돌릴 수 없습니다.',
+      });
+      expect(showConfirmation).toBeCalled();
+      await waitFor(() => expect(onClickDelete).not.toBeCalled());
+    });
+  });
+});

--- a/src/components/presentational/TableForm.jsx
+++ b/src/components/presentational/TableForm.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import Paper from '@material-ui/core/Paper';
-import Button from '@material-ui/core/Button';
-
 import TableContainer from '@material-ui/core/TableContainer';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+
+import DeleteButton from './DeleteButton';
 
 import { isEmpty } from '../../utils';
 
@@ -45,14 +45,9 @@ export default function TableForm(
                 </TableCell>
               ))}
               <TableCell>
-                <Button
-                  size="small"
-                  variant="contained"
-                  color="secondary"
-                  onClick={() => handleDeleteProduct(product)}
-                >
-                  Delete
-                </Button>
+                <DeleteButton
+                  onClickDelete={() => handleDeleteProduct(product)}
+                />
               </TableCell>
             </TableRow>
           ))}

--- a/src/contexts/ConfirmationContext.jsx
+++ b/src/contexts/ConfirmationContext.jsx
@@ -1,0 +1,62 @@
+import React, { createContext, useState, useRef } from 'react';
+
+import ConfirmDialog from '../components/presentational/ConfirmDialog';
+
+const ConfirmationContext = createContext({});
+
+const ConfirmationProvider = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [confirmForm, setConfirmForm] = useState({
+    title: '',
+    content: '',
+  });
+
+  const { title, content } = confirmForm;
+
+  const resolver = useRef();
+
+  const handleShowDialog = () => {
+    setIsOpen(true);
+    return new Promise((resolve) => {
+      resolver.current = resolve;
+    });
+  };
+
+  const handleOk = () => {
+    if (resolver.current) {
+      resolver.current(true);
+    }
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    if (resolver.current) {
+      resolver.current(false);
+    }
+    setIsOpen(false);
+  };
+
+  const value = {
+    showConfirmation: handleShowDialog,
+    setConfirmForm,
+  };
+
+  return (
+    <ConfirmationContext.Provider value={value}>
+      {children}
+      <ConfirmDialog
+        isOpen={isOpen}
+        title={title}
+        content={content}
+        onConfirm={handleOk}
+        onCancel={handleCancel}
+      />
+    </ConfirmationContext.Provider>
+  );
+};
+
+const { Consumer: ConfirmationConsumer } = ConfirmationContext;
+
+export { ConfirmationProvider, ConfirmationConsumer };
+
+export default ConfirmationContext;

--- a/src/contexts/ConfirmationContext.test.jsx
+++ b/src/contexts/ConfirmationContext.test.jsx
@@ -1,61 +1,9 @@
-// import React from 'react';
+import React from 'react';
 
-// import { fireEvent, render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
-// import { useDispatch, useSelector } from 'react-redux';
-
-// import ConfirmationContext from './ConfirmationContext';
-
-// import LoggedInUserSellProductsContainer from '../components/container/LoggedInUserSellProductsContainer';
-
-// import loggedInUserSellProducts from '../../fixtures/loggedInUserSellProducts';
-// import ConfirmDialog from '../components/presentational/ConfirmDialog';
-
-// jest.mock('react-redux');
-// describe('ConfirmationContext', () => {
-//   const dispatch = jest.fn();
-
-//   const showConfirmation = jest.fn();
-//   const setConfirmForm = jest.fn();
-
-//   beforeEach(() => {
-//     useDispatch.mockImplementation(() => dispatch);
-//     useSelector.mockImplementation((selector) => selector({
-//       productReducer: {
-//         loggedInUserSellProducts,
-//       },
-//     }));
-//   });
-
-//   it('test', async () => {
-//     setConfirmForm.mockImplementation(() => ({
-//       title: '삭제하시겠습니까?',
-//       content: '삭제하면 되돌릴 수 없습니다.',
-//     }));
-//     showConfirmation.mockImplementation(() => Promise.resolve(true));
-
-//     const { container, getAllByText } = render((
-//       <ConfirmationContext.Provider
-//         value={{
-//           showConfirmation,
-//           setConfirmForm,
-//         }}
-//       >
-//         <LoggedInUserSellProductsContainer />
-//         <ConfirmDialog
-//           isOpen
-//           title="삭제하시겠습니까?"
-//           content="삭제하면 되돌릴 수 없습니다."
-//           onConfirm={jest.fn()}
-//           onCancel={jest.fn()}
-//         />
-//       </ConfirmationContext.Provider>
-//     ));
-
-//     const deleteButtons = getAllByText('Delete');
-
-//     fireEvent.click(deleteButtons[0]);
-
-//     await waitFor(() => expect(showConfirmation).toBeCalled());
-//   });
-// });
+describe('ConfirmationContext', () => {
+  it('Confirmation Context provider', () => {
+    // TODO: Context test
+  });
+});

--- a/src/contexts/ConfirmationContext.test.jsx
+++ b/src/contexts/ConfirmationContext.test.jsx
@@ -1,0 +1,61 @@
+// import React from 'react';
+
+// import { fireEvent, render, waitFor } from '@testing-library/react';
+
+// import { useDispatch, useSelector } from 'react-redux';
+
+// import ConfirmationContext from './ConfirmationContext';
+
+// import LoggedInUserSellProductsContainer from '../components/container/LoggedInUserSellProductsContainer';
+
+// import loggedInUserSellProducts from '../../fixtures/loggedInUserSellProducts';
+// import ConfirmDialog from '../components/presentational/ConfirmDialog';
+
+// jest.mock('react-redux');
+// describe('ConfirmationContext', () => {
+//   const dispatch = jest.fn();
+
+//   const showConfirmation = jest.fn();
+//   const setConfirmForm = jest.fn();
+
+//   beforeEach(() => {
+//     useDispatch.mockImplementation(() => dispatch);
+//     useSelector.mockImplementation((selector) => selector({
+//       productReducer: {
+//         loggedInUserSellProducts,
+//       },
+//     }));
+//   });
+
+//   it('test', async () => {
+//     setConfirmForm.mockImplementation(() => ({
+//       title: '삭제하시겠습니까?',
+//       content: '삭제하면 되돌릴 수 없습니다.',
+//     }));
+//     showConfirmation.mockImplementation(() => Promise.resolve(true));
+
+//     const { container, getAllByText } = render((
+//       <ConfirmationContext.Provider
+//         value={{
+//           showConfirmation,
+//           setConfirmForm,
+//         }}
+//       >
+//         <LoggedInUserSellProductsContainer />
+//         <ConfirmDialog
+//           isOpen
+//           title="삭제하시겠습니까?"
+//           content="삭제하면 되돌릴 수 없습니다."
+//           onConfirm={jest.fn()}
+//           onCancel={jest.fn()}
+//         />
+//       </ConfirmationContext.Provider>
+//     ));
+
+//     const deleteButtons = getAllByText('Delete');
+
+//     fireEvent.click(deleteButtons[0]);
+
+//     await waitFor(() => expect(showConfirmation).toBeCalled());
+//   });
+// });

--- a/src/pages/AboutMePage.jsx
+++ b/src/pages/AboutMePage.jsx
@@ -12,6 +12,8 @@ import LoggedInUserSellProductsContainer from '../components/container/LoggedInU
 
 import { loadItem } from '../services/storage';
 
+import { ConfirmationProvider } from '../contexts/ConfirmationContext';
+
 import useStyles from '../styles/styles';
 
 export default function AboutMePage() {
@@ -48,8 +50,10 @@ export default function AboutMePage() {
         <Tab label="판매중인 상품" />
         <Tab label="찜한 상품" />
       </Tabs>
-      {selectedTab === 0 && <LoggedInUserSellProductsContainer user={user} />}
-      {/* TODO : 찜한 상품 리스트 추가 {selectedTab === 1 && <MyWishListContainer />} */}
+      <ConfirmationProvider>
+        {selectedTab === 0 && <LoggedInUserSellProductsContainer user={user} />}
+        {/* TODO : 찜한 상품 리스트 추가 {selectedTab === 1 && <MyWishListContainer />} */}
+      </ConfirmationProvider>
     </Container>
   );
 }


### PR DESCRIPTION
![delete dialog](https://user-images.githubusercontent.com/45390172/100042446-cf966980-2e4e-11eb-9f37-95cb784775a2.gif)

- 삭제 버튼을 누르면 삭제 경고 메세지를 띄우는 confirm dialog
  component를 만들었다.

- redux로 만드려고 했을 때는 함수를 store 안의 state로 넣으면 직렬화
  값이 아니라는 경고가 떠서 하지 못했다.

- ConfirmDialog 테스트 중 dialog창이 뜨려면 시간이 걸려 waitFor를
  적용하였다.

- Context 컴포넌트에 대한 테스트를 어떻게 해야 할지 몰라서 보류했다.

### source
- `Context api`를 이용하여 `confirm dialog` 를 사용하는 방법에 대한 포스팅을 참고함
https://levelup.gitconnected.com/how-to-build-a-generic-reusable-synchronous-like-confirmation-dialog-in-react-js-71e32dfa495c