### PR TITLE
Implement categories select box in write page

### DIFF
--- a/fixtures/products.js
+++ b/fixtures/products.js
@@ -7,6 +7,7 @@ const products = [
     },
     id: 1,
     title: '크리넥스 KF-AD 소형 마스크 팝니다.',
+    category: '기타 중고물품',
     productImages: [
       'testImage1',
       'testImage2',
@@ -24,6 +25,7 @@ const products = [
     },
     id: 2,
     title: '알레르망 범퍼침대',
+    category: '가구/인테리어',
     productImages: [
       'testImage4',
       'testImage5',
@@ -41,6 +43,7 @@ const products = [
     },
     id: 3,
     title: '청바지',
+    category: '남성패션/잡화',
     productImages: [
       'testImage7',
       'testImage8',
@@ -60,6 +63,7 @@ const products = [
     },
     id: 4,
     title: '아이패드 에어3',
+    category: '디지털/가전',
     productImages: [
       'https://via.placeholder.com/600/197d29',
       'https://via.placeholder.com/600/24f355',
@@ -77,6 +81,7 @@ const products = [
     },
     id: 5,
     title: '겔럭시S7 핑크블로썸 팝니다.',
+    category: '디지털/가전',
     productImages: [
       'https://via.placeholder.com/600/f9cee5',
       'https://via.placeholder.com/600/51aa97',

--- a/src/components/container/LoggedInUserSellProductsContainer.jsx
+++ b/src/components/container/LoggedInUserSellProductsContainer.jsx
@@ -11,7 +11,7 @@ import TableForm from '../presentational/TableForm';
 
 const columns = [
   { id: 1, name: 'title', label: '상품 이름' },
-  { id: 2, name: 'categories', label: '카테고리' },
+  { id: 2, name: 'category', label: '카테고리' },
   { id: 3, name: 'price', label: '가격' },
 ];
 

--- a/src/components/container/LoggedInUserSellProductsContainer.jsx
+++ b/src/components/container/LoggedInUserSellProductsContainer.jsx
@@ -11,7 +11,8 @@ import TableForm from '../presentational/TableForm';
 
 const columns = [
   { id: 1, name: 'title', label: '상품 이름' },
-  { id: 2, name: 'price', label: '가격' },
+  { id: 2, name: 'categories', label: '카테고리' },
+  { id: 3, name: 'price', label: '가격' },
 ];
 
 export default function LoggedInUserSellProductsContainer({ user }) {

--- a/src/components/container/WriteFormContainer.test.jsx
+++ b/src/components/container/WriteFormContainer.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import {
+  fireEvent, render, waitFor, within,
+} from '@testing-library/react';
 
 import { useDispatch } from 'react-redux';
 
@@ -22,10 +24,11 @@ describe('WriteFormContainer', () => {
 
   context('when all forms are filled', () => {
     it('possible submit event', async () => {
-      const { container } = renderWriteFormContainer();
+      const { container, getAllByRole, getByRole } = renderWriteFormContainer();
 
       const title = container.querySelector('input[name="title"]');
       const description = container.querySelector('textarea[name="description"]');
+      const categories = getAllByRole('button')[0];
       const price = container.querySelector('input[name="price"]');
       const region = container.querySelector('input[name="region"]');
 
@@ -36,6 +39,10 @@ describe('WriteFormContainer', () => {
           },
         });
       });
+
+      fireEvent.mouseDown(categories);
+      const listbox = within(getByRole('listbox'));
+      fireEvent.click(listbox.getByText(/디지털\/가전/i));
 
       await waitFor(() => {
         fireEvent.change(description, {

--- a/src/components/container/WriteFormContainer.test.jsx
+++ b/src/components/container/WriteFormContainer.test.jsx
@@ -28,7 +28,7 @@ describe('WriteFormContainer', () => {
 
       const title = container.querySelector('input[name="title"]');
       const description = container.querySelector('textarea[name="description"]');
-      const categories = getAllByRole('button')[0];
+      const category = getAllByRole('button')[0];
       const price = container.querySelector('input[name="price"]');
       const region = container.querySelector('input[name="region"]');
 
@@ -40,7 +40,7 @@ describe('WriteFormContainer', () => {
         });
       });
 
-      fireEvent.mouseDown(categories);
+      fireEvent.mouseDown(category);
       const listbox = within(getByRole('listbox'));
       fireEvent.click(listbox.getByText(/디지털\/가전/i));
 

--- a/src/components/presentational/FormikSelect.jsx
+++ b/src/components/presentational/FormikSelect.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { Field, ErrorMessage } from 'formik';
+
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import Select from '@material-ui/core/Select';
+import FormHelperText from '@material-ui/core/FormHelperText';
+
+import MenuItem from '@material-ui/core/MenuItem';
+
+const MaterialUISelectField = ({
+  error,
+  errorString,
+  label,
+  children,
+  value,
+  name,
+  onChange,
+  onBlur,
+}) => (
+  <FormControl fullWidth error={error}>
+    <InputLabel>{label}</InputLabel>
+    <Select name={name} onChange={onChange} onBlur={onBlur} value={value}>
+      {children}
+    </Select>
+    <FormHelperText>{errorString}</FormHelperText>
+  </FormControl>
+);
+
+export default function FormikSelect({
+  name, error, items, label,
+}) {
+  return (
+    <Field
+      name={name}
+      as={MaterialUISelectField}
+      label={label}
+      error={error}
+      errorString={<ErrorMessage name={name} />}
+    >
+      {items.map((item) => (
+        <MenuItem key={item.value} value={item.value}>
+          {item.label}
+        </MenuItem>
+      ))}
+    </Field>
+  );
+}

--- a/src/components/presentational/ProductDetail.jsx
+++ b/src/components/presentational/ProductDetail.jsx
@@ -17,7 +17,7 @@ export default function ProductDetail({ product }) {
   const {
     productImages,
     title,
-    categories,
+    category,
     region,
     price,
     description,
@@ -53,7 +53,7 @@ export default function ProductDetail({ product }) {
       <ArticleProfile user={user} region={region} />
       <ArticleDescription>
         <h1 className="article article-title">{title}</h1>
-        <p className="article article-category">{`${categories}`}</p>
+        <p className="article article-category">{`${category}`}</p>
         <p className="article article-price">{`${price}원`}</p>
         <p className="article article-description">{description}</p>
       </ArticleDescription>

--- a/src/components/presentational/ProductDetail.jsx
+++ b/src/components/presentational/ProductDetail.jsx
@@ -15,7 +15,13 @@ import ArticleProfile from './ArticleProfile';
 
 export default function ProductDetail({ product }) {
   const {
-    productImages, title, region, price, description, user,
+    productImages,
+    title,
+    categories,
+    region,
+    price,
+    description,
+    user,
   } = product;
   const classes = useStyles();
 
@@ -47,6 +53,7 @@ export default function ProductDetail({ product }) {
       <ArticleProfile user={user} region={region} />
       <ArticleDescription>
         <h1 className="article article-title">{title}</h1>
+        <p className="article article-category">{`${categories}`}</p>
         <p className="article article-price">{`${price}원`}</p>
         <p className="article article-description">{description}</p>
       </ArticleDescription>
@@ -122,6 +129,10 @@ const ArticleDescription = styled.section({
     fontSize: '20px',
     fontWeight: '600',
     lineHeight: '1.5',
+  },
+  '& .article-category': {
+    marginTop: 0,
+    color: '#868e96',
   },
   '& .article-price': {
     fontSize: '18px',

--- a/src/components/presentational/TableForm.test.jsx
+++ b/src/components/presentational/TableForm.test.jsx
@@ -15,7 +15,8 @@ describe('TableForm', () => {
 
   const columns = [
     { id: 1, name: 'title', label: '상품 이름' },
-    { id: 2, name: 'price', label: '가격' },
+    { id: 2, name: 'categories', label: '카테고리' },
+    { id: 3, name: 'price', label: '가격' },
   ];
 
   function renderTableForm({ products }) {

--- a/src/components/presentational/TableForm.test.jsx
+++ b/src/components/presentational/TableForm.test.jsx
@@ -15,7 +15,7 @@ describe('TableForm', () => {
 
   const columns = [
     { id: 1, name: 'title', label: '상품 이름' },
-    { id: 2, name: 'categories', label: '카테고리' },
+    { id: 2, name: 'category', label: '카테고리' },
     { id: 3, name: 'price', label: '가격' },
   ];
 

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -16,7 +16,7 @@ const validationSchema = yup.object({
   title: yup
     .string()
     .required('필수 항목입니다.'),
-  categories: yup
+  category: yup
     .string()
     .required('필수 항목입니다.'),
   description: yup
@@ -32,7 +32,7 @@ const validationSchema = yup.object({
 
 const initialValues = {
   title: '',
-  categories: '',
+  category: '',
   description: '',
   price: '',
   region: '',
@@ -101,10 +101,10 @@ export default function WriteForm({ onSubmit }) {
               <Grid item xs={6}>
                 <FormikSelect
                   label="카테고리"
-                  id="product-categories"
+                  id="product-category"
                   items={categories}
-                  name="categories"
-                  error={touched.categories && Boolean(errors.categories)}
+                  name="category"
+                  error={touched.category && Boolean(errors.category)}
                 />
               </Grid>
               <Grid item xs={6}>

--- a/src/components/presentational/WriteForm.jsx
+++ b/src/components/presentational/WriteForm.jsx
@@ -6,12 +6,17 @@ import * as yup from 'yup';
 import {
   Button, Grid, InputAdornment,
 } from '@material-ui/core';
+
 import FormikField from './FormikField';
+import FormikSelect from './FormikSelect';
 
 import useStyles from '../../styles/styles';
 
 const validationSchema = yup.object({
   title: yup
+    .string()
+    .required('필수 항목입니다.'),
+  categories: yup
     .string()
     .required('필수 항목입니다.'),
   description: yup
@@ -27,10 +32,42 @@ const validationSchema = yup.object({
 
 const initialValues = {
   title: '',
+  categories: '',
   description: '',
   price: '',
   region: '',
 };
+
+const categories = [
+  {
+    label: '디지털/가전',
+    value: '디지털/가전',
+  },
+  {
+    label: '가구/인테리어',
+    value: '가구/인테리어',
+  },
+  {
+    label: '남성패션/잡화',
+    value: '남성패션/잡화',
+  },
+  {
+    label: '여성의류',
+    value: '여성의류',
+  },
+  {
+    label: '생활/가공식품',
+    value: '생활/가공식품',
+  },
+  {
+    label: '스포츠/레저',
+    value: '스포츠/레저',
+  },
+  {
+    label: '기타 중고물품',
+    value: '기타 중고물품',
+  },
+];
 
 export default function WriteForm({ onSubmit }) {
   const classes = useStyles();
@@ -53,12 +90,21 @@ export default function WriteForm({ onSubmit }) {
               spacing={3}
               className={classes.form}
             >
-              <Grid item xs={12}>
+              <Grid item xs={6}>
                 <FormikField
                   label="글 제목"
                   id="write-title"
                   name="title"
                   error={touched.title && Boolean(errors.title)}
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <FormikSelect
+                  label="카테고리"
+                  id="product-categories"
+                  items={categories}
+                  name="categories"
+                  error={touched.categories && Boolean(errors.categories)}
                 />
               </Grid>
               <Grid item xs={6}>

--- a/src/components/presentational/WriteForm.test.jsx
+++ b/src/components/presentational/WriteForm.test.jsx
@@ -11,7 +11,7 @@ describe('WriteForm', () => {
 
   const controls = [
     { control: 'input', name: 'title', text: '아이패드' },
-    { control: 'input', name: 'categories', text: '디지털/가전' },
+    { control: 'input', name: 'category', text: '디지털/가전' },
     { control: 'input', name: 'region', text: '인천' },
     { control: 'input', name: 'price', text: '200000' },
     { control: 'textarea', name: 'description', text: '중고 팝니다.' },
@@ -45,7 +45,7 @@ describe('WriteForm', () => {
 
       const title = container.querySelector('input[name="title"]');
       const description = container.querySelector('textarea[name="description"]');
-      const categories = getAllByRole('button')[0];
+      const category = getAllByRole('button')[0];
       const price = container.querySelector('input[name="price"]');
       const region = container.querySelector('input[name="region"]');
 
@@ -57,7 +57,7 @@ describe('WriteForm', () => {
         });
       });
 
-      fireEvent.mouseDown(categories);
+      fireEvent.mouseDown(category);
       const listbox = within(getByRole('listbox'));
       fireEvent.click(listbox.getByText(/디지털\/가전/i));
 
@@ -94,7 +94,7 @@ describe('WriteForm', () => {
       expect(handleSubmit).toHaveBeenCalledWith({
         newProduct: {
           title: '아이패드',
-          categories: '디지털/가전',
+          category: '디지털/가전',
           description: '중고 아이패드 팝니다.',
           price: 1234,
           region: '인천',

--- a/src/components/presentational/WriteForm.test.jsx
+++ b/src/components/presentational/WriteForm.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {
-  render, fireEvent, waitFor,
+  render, fireEvent, waitFor, within,
 } from '@testing-library/react';
 
 import WriteForm from './WriteForm';
@@ -11,6 +11,7 @@ describe('WriteForm', () => {
 
   const controls = [
     { control: 'input', name: 'title', text: '아이패드' },
+    { control: 'input', name: 'categories', text: '디지털/가전' },
     { control: 'input', name: 'region', text: '인천' },
     { control: 'input', name: 'price', text: '200000' },
     { control: 'textarea', name: 'description', text: '중고 팝니다.' },
@@ -38,10 +39,13 @@ describe('WriteForm', () => {
 
   context('when all forms are filled', () => {
     it('possible submit event', async () => {
-      const { container } = renderWriteForm();
+      const {
+        container, getAllByRole, getByRole,
+      } = renderWriteForm();
 
       const title = container.querySelector('input[name="title"]');
       const description = container.querySelector('textarea[name="description"]');
+      const categories = getAllByRole('button')[0];
       const price = container.querySelector('input[name="price"]');
       const region = container.querySelector('input[name="region"]');
 
@@ -52,6 +56,10 @@ describe('WriteForm', () => {
           },
         });
       });
+
+      fireEvent.mouseDown(categories);
+      const listbox = within(getByRole('listbox'));
+      fireEvent.click(listbox.getByText(/디지털\/가전/i));
 
       await waitFor(() => {
         fireEvent.change(description, {
@@ -85,7 +93,11 @@ describe('WriteForm', () => {
 
       expect(handleSubmit).toHaveBeenCalledWith({
         newProduct: {
-          description: '중고 아이패드 팝니다.', price: 1234, region: '인천', title: '아이패드',
+          title: '아이패드',
+          categories: '디지털/가전',
+          description: '중고 아이패드 팝니다.',
+          price: 1234,
+          region: '인천',
         },
       });
     });


### PR DESCRIPTION
<img width="992" alt="스크린샷 2020-11-30 오후 6 06 23" src="https://user-images.githubusercontent.com/45390172/100589722-d03f6c00-3336-11eb-8f6a-0cce993260de.png">
<img width="951" alt="스크린샷 2020-11-30 오후 6 06 58" src="https://user-images.githubusercontent.com/45390172/100589758-d9c8d400-3336-11eb-8712-601491e3c25e.png">

- `writeForm` 컴포넌트에 판매 상품의 카테고리를 선택할 수 있는 `FormikSelect` 컴포넌트를 만들고 적용하였습니다.
- 내 정보에서 해당 상품의 카테고리도 볼 수 있도록 하였습니다.

source
- [material ui와 formik을 이용하여 select 구현하기](https://github.com/angle943/formik-material-ui)
- [react testing library로 select 선택 테스트 하는 방법](https://stackoverflow.com/questions/55184037/react-testing-library-on-change-for-material-ui-select-component/61491607#61491607)
- [material ui의 select 테스트 코드들](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Select/Select.test.js)