### PR TITLE
Change product image save path in storage

### DIFF
--- a/src/productSlice.js
+++ b/src/productSlice.js
@@ -75,9 +75,9 @@ export function postProduct({ files, newProduct }) {
       },
     } = getState();
 
-    const productImages = await uploadProductImages({
-      uid: user.uid, files,
-    });
+    const createAt = Date.now();
+    const path = `${user.email}/${newProduct.title}${createAt}`;
+    const productImages = await uploadProductImages({ files, path });
 
     await postProductFireStore({
       ...newProduct,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -41,10 +41,10 @@ export async function fetchloggedInUserSellProducts({ user }) {
   return loggedInUserSellProducts;
 }
 
-export async function uploadProductImages({ uid, files }) {
+export async function uploadProductImages({ files, path }) {
   async function uploadProductImage(file) {
     const uploadTask = firebase.storage()
-      .ref().child(`${uid}/${uuidv4()}`);
+      .ref().child(`${path}/${file.id}`);
     const response = await uploadTask.put(file);
     const imageUrl = await response.ref.getDownloadURL();
     return imageUrl;


### PR DESCRIPTION
<img width="1296" alt="스크린샷 2020-12-04 오후 5 45 36" src="https://user-images.githubusercontent.com/45390172/101142108-85846380-3658-11eb-9a7b-6103e555f6e0.png">
<img width="1295" alt="스크린샷 2020-12-04 오후 5 44 36" src="https://user-images.githubusercontent.com/45390172/101142007-64237780-3658-11eb-9f1d-00ce783e4079.png">
<img width="1296" alt="스크린샷 2020-12-04 오후 5 45 10" src="https://user-images.githubusercontent.com/45390172/101142074-79000b00-3658-11eb-80a0-3c6d11a13236.png">

firebase storage에 이미지를 저장하는 경로를 바꿨다.

기존 : 유저아이디/파일아이디

그래서 해당 유저가 판매하는 모든 상품이 유저아이디 폴더에 모두
모여있어서 구분하기 어려웠다.

새 경로 : 유저이메일/판매글제목 판매글작성 시간/파일아이디

이로써 해당 판매글만 그룹지어 저장할 수 있다.
