### PR TITLE
Update webpack config file

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,5 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="/main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Codesoom project",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server",
-    "build": "webpack --mode production --config webpack.config.js",
-    "build:dev": "webpack --mode development --config webpack.config.js",
+    "start": "webpack-dev-server --progress",
+    "build": "NODE_ENV=production webpack --config webpack.config.js",
+    "build:dev": "webpack --config webpack.config.js",
     "test:unit": "jest",
     "coverage": "npm run test:unit -- --coverage",
     "test": "npm run coverage && start-server-and-test start http://localhost:8080 test:e2e",
@@ -57,7 +57,7 @@
     "start-server-and-test": "^1.11.2",
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.0",
-    "webpack": "^4.44.0",
+    "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,13 +3,17 @@ const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const mode = process.env.NODE_ENV || 'development';
+
 module.exports = {
+  mode,
   entry: path.resolve(__dirname, 'src/index.jsx'),
   output: {
-    path: path.resolve(__dirname, './dist'),
+    path: path.resolve(__dirname, 'dist'),
     filename: 'bundle-[hash].js',
     publicPath: '/',
   },
+  devtool: 'inline-source-map',
   module: {
     rules: [
       {
@@ -51,9 +55,11 @@ module.exports = {
     extensions: ['.js', '.jsx'],
   },
   devServer: {
-    historyApiFallback: {
-      index: 'index.html',
-    },
+    open: true,
+    overlay: true,
+    hot: true,
+    stats: 'errors-only',
+    historyApiFallback: true,
   },
   plugins: [
     new CleanWebpackPlugin(),


### PR DESCRIPTION
* index.html의 script 태그를 삭제했다.
webpack-dev-server를 이용할때 webpack.config.js 파일에 output 설정이
없으면 index.html 파일에서의 main.js를 잘 불러왔다. 하지만 output이 생긴
이후로는 main.js를 찾지 못하고 bundle 결과를 script 태그로
불러오는현상이 나타났다.

webpack.config.js에서 devServer 부분의 contentBase가 기본값이 웹팩
아웃풋이라고 한다. 그러므로 main을 지워주어야 하는 듯 하다.

* devServer 부분에 여러 옵션을 추가한다.

* package.json의 scripts 를 수정하였다.